### PR TITLE
Manage tuple/list for input/output soap headers

### DIFF
--- a/src/rpclib/interface/_base.py
+++ b/src/rpclib/interface/_base.py
@@ -246,14 +246,22 @@ class Base(object):
                     method.out_header = s.__out_header__
 
                 if not (method.in_header is None):
-                    method.in_header.resolve_namespace(method.in_header,
-                                                                 self.get_tns())
-                    method.in_header.add_to_schema(self)
+                    if isinstance(method.in_header, (list, tuple)):
+                        in_headers = method.in_header
+                    else:
+                        in_headers = (method.in_header,)
+                    for in_header in in_headers:
+                        in_header.resolve_namespace(in_header, self.get_tns())
+                        in_header.add_to_schema(self)
 
                 if not (method.out_header is None):
-                    method.out_header.resolve_namespace(method.out_header,
-                                                                 self.get_tns())
-                    method.out_header.add_to_schema(self)
+                    if isinstance(method.out_header, (list,tuple)):
+                        out_headers = method.out_header
+                    else:
+                        out_headers = (method.out_header,)
+                    for out_header in out_headers:
+                        out_header.resolve_namespace(out_header, self.get_tns())
+                        out_header.add_to_schema(self)
 
                 method.in_message.resolve_namespace(method.in_message,
                                                                  self.get_tns())

--- a/src/rpclib/test/interop/server/_service.py
+++ b/src/rpclib/test/interop/server/_service.py
@@ -101,6 +101,18 @@ class OutHeader(ComplexModel):
     dt=DateTime
     f=Float
 
+class InTraceHeader(ComplexModel):
+    __namespace__ = "rpclib.test.interop.server"
+
+    client=String
+    callDate=DateTime
+
+class OutTraceHeader(ComplexModel):
+    __namespace__ = "rpclib.test.interop.server"
+
+    receiptDate=DateTime
+    returnDate=DateTime
+
 class InteropServiceWithHeader(ServiceBase):
     __in_header__ = InHeader
     __out_header__ = OutHeader
@@ -114,6 +126,28 @@ class InteropServiceWithHeader(ServiceBase):
         ctx.out_header = OutHeader()
         ctx.out_header.dt = datetime(year=2000, month=01, day=01)
         ctx.out_header.f = 3.141592653
+
+        return ctx.out_header
+
+class InteropServiceWithComplexHeader(ServiceBase):
+    __in_header__ = (InHeader, InTraceHeader)
+    __out_header__ = (OutHeader, OutTraceHeader)
+
+    @rpc(_returns=(InHeader, InTraceHeader))
+    def echo_in_complex_header(ctx):
+        return ctx.in_header
+
+    @rpc(_returns=(OutHeader, OutTraceHeader))
+    def send_out_complex_header(ctx):
+        out_header = OutHeader()
+        out_header.dt = datetime(year=2000, month=01, day=01)
+        out_header.f = 3.141592653
+        out_trace_header = OutTraceHeader()
+        out_trace_header.receiptDate = datetime(year=2000, month=01, day=01,
+                                  hour=01, minute=01, second=01, microsecond=01)
+        out_trace_header.returnDate = datetime(year=2000, month=01, day=01,
+                                 hour=01, minute=01, second=01, microsecond=100)
+        ctx.out_header = (out_header, out_trace_header)
 
         return ctx.out_header
 
@@ -301,5 +335,6 @@ services = [
     InteropClass,
     InteropMisc,
     InteropServiceWithHeader,
+    InteropServiceWithComplexHeader,
     InteropException,
 ]


### PR DESCRIPTION
Here is the modification for managing input and output headers either as a single type/element or as a tuple/list of types/elements

I added 2 corresponding tests for these complex headers.

While looking at the code of interface/wsdl.py, I think i saw some bugs in add_port_type function :
- the definition of operations references messages using  method.in_message.get_type_name_ns(interface) whereas the namespace should be tns (this is always the case for message). Actually, the message attribute of the input/output elements would reference the message element definition rather than the message itself. It works for the actual tests because everything is in the target namespace. (on the contrary, declaration of messages in add_bindings_for_methods is correct)
- The definition of faults use f.get_type_name(interface) which is, I think invalid (should be either get_type_name() or get_type_name_ns(interface)). Anyway, the above remark also applies here.

Just another remark : the add_port_type, add_messages_for_methods and add_bindings_for_methods have a parameter which is a Wsdl11 instance (interface or app parameter), so I think these functions should be Wsdl11 methods.
