### PR TITLE
fix: TypeError: object of type 'int' has no len()

### DIFF
--- a/src/rpclib/server/wsgi.py
+++ b/src/rpclib/server/wsgi.py
@@ -43,7 +43,7 @@ BLOCK_LENGTH = 8 * 1024
 def _wsgi_input_to_iterable(http_env):
     istream = http_env.get('wsgi.input')
 
-    length = http_env.get('CONTENT_LENGTH', str(MAX_CONTENT_LENGTH))
+    length = str(http_env.get('CONTENT_LENGTH', MAX_CONTENT_LENGTH))
     if len(length) == 0:
         length = 0
     else:


### PR DESCRIPTION
```
def _wsgi_input_to_iterable(http_env):
    istream = http_env.get('wsgi.input')

    length = http_env.get('CONTENT_LENGTH', str(MAX_CONTENT_LENGTH))
    if len(length) == 0:
```

rpclib/server/wsgi.py:47
