### PR TITLE
Enum.__nonzero__ behaviour

### DIFF
--- a/src/rpclib/model/enum.py
+++ b/src/rpclib/model/enum.py
@@ -66,7 +66,7 @@ def Enum(*values, **kwargs):
             return values[maximum - self.__value]
 
         def __nonzero__(self):
-            return bool(self.__value)
+            return bool(values[self.__value])
 
         def __bool__(self):
             return bool(self.__value)

--- a/src/rpclib/test/model/test_enum.py
+++ b/src/rpclib/test/model/test_enum.py
@@ -92,6 +92,15 @@ class TestEnum(unittest.TestCase):
         ret = XmlObject().from_element(DaysOfWeekEnum, elt)
 
         self.assertEquals(mo, ret)
+    
+    def test_nonzero(self):
+        DaysOfWeekEnum.resolve_namespace(DaysOfWeekEnum, 'punk')
+        mo = DaysOfWeekEnum.Monday
+        tue = DaysOfWeekEnum.Tuesday
+        print((repr(mo)))
+
+        self.assertFalse(not tue)
+        self.assertFalse(not mo, "First Enum element is using 'bool(0)' as it's '__nonzero__'")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Found this when attempting some internal Enum validation. Don't know if it makes sense but I just figured I'd share my thoughts.

Congrats on rpclib - it's awesome.
