### PR TITLE
primitives: int()s do not have __len__; cast to str() first

### DIFF
--- a/rpclib/model/primitive.py
+++ b/rpclib/model/primitive.py
@@ -331,7 +331,7 @@ class Integer(Decimal):
     @classmethod
     @nillable_string
     def from_string(cls, string):
-        if cls.__max_str_len__ is not None and len(string) > cls.__max_str_len__:
+        if cls.__max_str_len__ is not None and len(str(string)) > cls.__max_str_len__:
             raise Fault('Client.ValidationError', 'String longer than '
                         '%d characters.' % cls.__max_str_len__)
 


### PR DESCRIPTION
without this, `from_string` fails with:

object of type 'int' has no len()

... I have a custom `from_json` and `to_json` methods that use `from_string` to load primitives into native types.
