### PR TITLE
Members with nillable=false and maxOccurs=0 still set nillable

### DIFF
--- a/rpclib/protocol/xml/model.py
+++ b/rpclib/protocol/xml/model.py
@@ -145,7 +145,7 @@ def get_members_etree(prot, cls, inst, parent):
                 prot.to_parent_element(v, sv, cls.get_namespace(), parent, k)
 
         # Don't include empty values for non-nillable optional attributes.
-        elif subvalue is not None or (not v.Attributes.nillable or v.Attributes.min_occurs > 0):
+        elif subvalue is not None or v.Attributes.min_occurs > 0:
             prot.to_parent_element(v, subvalue, cls.get_namespace(), parent, k)
 
 


### PR DESCRIPTION
Currently, when an element is optional, but NOT nillable, it's still set
nillable during serialization. However, when nillable=true, the member is
properly skipped. This behavior causes schema validation errors on the client.

Example schema:

``` xml
    <xs:complexType name="object">
        <xs:sequence>
            [...]
            <xs:element name="id" type="xs:string" minOccurs="0" />
            <xs:element name="account" type="tns:account" minOccurs="0" />
            <xs:element name="last_updated" type="xs:dateTime" minOccurs="0" />
            [...]
        </xs:sequence>
    </xs:complexType>
```

Rpclib output:

``` xml
    <tns:object>
        [...]
        <tns:id>4fd7ad136b6b473006000005</tns:id>
        <tns:account xsi:nil="true"/>
        <tns:last_updated xsi:nil="true"/>
        [...]
    </tns:object>
```

... correct by not caring if nillable when deciding to skip or not.
