### PR TITLE
[issue #143] Soft validation: Attributes._has_non_nillable_children

### DIFF
--- a/rpclib/protocol/xml/model.py
+++ b/rpclib/protocol/xml/model.py
@@ -51,9 +51,8 @@ def nillable_value(func):
 def nillable_element(func):
     def wrapper(prot, cls, element):
         if bool(element.get('{%s}nil' % _ns_xsi)):
-            if prot.validator is prot.SOFT_VALIDATION and (
-                        not cls.Attributes.nillable or
-                                    cls.Attributes._has_non_nillable_children):
+            if (prot.validator is prot.SOFT_VALIDATION and
+                        not cls.Attributes.nillable):
                 raise ValidationError('')
             else:
                 return cls.Attributes.default


### PR DESCRIPTION
When soft-validating nillable strings, validation fails due to checking a
non-existent attr. Since attr is not mentioned or used anywhere else in the
library it's likely a forgotten detail from a previous impl.
