### PR TITLE
[issue #145] Unicode.validate_string: do not pass None to re.match

### DIFF
--- a/rpclib/model/primitive.py
+++ b/rpclib/model/primitive.py
@@ -191,10 +191,10 @@ class Unicode(SimpleModel):
         return (     SimpleModel.validate_string(cls, value)
                 and (value is None or (
                         len(value) >= cls.Attributes.min_len and
-                        len(value) <= cls.Attributes.max_len))
+                        len(value) <= cls.Attributes.max_len
                 and (cls.Attributes.pattern is None or
                             re.match(cls.Attributes.pattern, value) is not None)
-            )
+            )))
 
 
 class String(Unicode):


### PR DESCRIPTION
Nillable strings which also define an Attributes.pattern end up passing None to
re.match, throwing `TypeError: expected string or buffer`. Correct by running
regex check only if value is not None.
