### PR TITLE
[issue #147] XML comments processed as data elements

### DIFF
--- a/rpclib/protocol/soap/soap11.py
+++ b/rpclib/protocol/soap/soap11.py
@@ -76,9 +76,11 @@ def _parse_xml_string(xml_string, charset=None):
     else:
         string = ''.join(xml_string)
 
+    parser = etree.XMLParser(remove_comments=True)
+
     try:
         try:
-            root, xmlids = etree.XMLID(string)
+            root, xmlids = etree.XMLID(string, parser)
 
         except XMLSyntaxError, e:
             logger.error(string)
@@ -87,7 +89,7 @@ def _parse_xml_string(xml_string, charset=None):
     except ValueError, e:
         logger.debug('%r -- falling back to str decoding.' % (e))
         try:
-            root, xmlids = etree.XMLID(string.encode(charset))
+            root, xmlids = etree.XMLID(string.encode(charset), parser)
         except XMLSyntaxError, e:
             logger.error(string)
             raise Fault('Client.XMLSyntaxError', str(e))

--- a/rpclib/protocol/xml/_base.py
+++ b/rpclib/protocol/xml/_base.py
@@ -171,11 +171,14 @@ class XmlObject(ProtocolBase):
         """Uses the iterable of string fragments in ``ctx.in_string`` to set
         ``ctx.in_document``."""
 
+        parser = etree.XMLParser(remove_comments=True)
+
         try:
-            ctx.in_document = etree.fromstring(_bytes_join(ctx.in_string))
+            ctx.in_document = etree.fromstring(_bytes_join(ctx.in_string), parser)
         except ValueError:
             ctx.in_document = etree.fromstring(_bytes_join(ctx.in_string) \
-                                                               .decode(charset))
+                                                               .decode(charset),
+                                               parser)
 
     def decompose_incoming_envelope(self, ctx, message):
         assert message in (self.REQUEST, self.RESPONSE)


### PR DESCRIPTION
As XML comments are considered nodes during iteration, their presence leads
to the instatiation of empty Models.  Comments should not carry protocol data
and are therefore safe to ignore.
