### PR TITLE
Use decimal.Decimal() to represent Infinity

### DIFF
--- a/doc/source/manual/validation.rst
+++ b/doc/source/manual/validation.rst
@@ -88,7 +88,7 @@ along with their default values
   set to ``unbounded`` for arbitrary number of arguments
 
   .. NOTE::
-    As of spyne-2.8.0, use ``float('inf')`` instead of ``unbounded``.
+    As of spyne-2.8.0, use ``decimal.Decimal('inf')`` instead of ``unbounded``.
 
 These rules can be combined, the example below illustrates how to create a
 mandatory string:

--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 #
 
+import decimal
 import logging
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ def complex_add(document, cls):
             member.set('minOccurs', str(v.Attributes.min_occurs))
         if v.Attributes.max_occurs != 1: # 1 is the xml schema default
             val = v.Attributes.max_occurs
-            if val == float('inf'):
+            if val == decimal.Decimal('inf'):
                 val = 'unbounded'
             else:
                 val = str(val)

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -90,7 +90,7 @@ class ModelBase(object):
         max_occurs = 1
         """Can be set to any strictly positive integer. Values greater than 1
         will imply an iterable of objects as native python type. Can be set to
-        ``float("inf")`` for arbitrary number of arguments."""
+        ``decimal.Decimal("inf")`` for arbitrary number of arguments."""
 
         schema_tag = '{%s}element' % spyne.const.xml_ns.xsd
         """The tag used to add a primitives as child to a complex type in the

--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -21,6 +21,7 @@
 mainly container classes that organize other values.
 """
 
+import decimal
 import logging
 logger = logging.getLogger(__name__)
 
@@ -432,7 +433,7 @@ class Array(ComplexModel):
         # hack to default to unbounded arrays when the user didn't specify
         # max_occurs. We should find a better way.
         if serializer.Attributes.max_occurs == 1:
-            serializer = serializer.customize(max_occurs=float('inf'))
+            serializer = serializer.customize(max_occurs=decimal.Decimal('inf'))
 
         if serializer.get_type_name() is ModelBase.Empty:
             member_name = serializer.__base_type__.get_type_name()

--- a/spyne/model/primitive.py
+++ b/spyne/model/primitive.py
@@ -133,8 +133,8 @@ class Unicode(SimpleModel):
         min_len = 0
         """Minimum length of string. Can be set to any positive integer"""
 
-        max_len = float('inf')
-        """Maximum length of string. Can be set to ``float('inf')`` to accept
+        max_len = decimal.Decimal('inf')
+        """Maximum length of string. Can be set to ``decimal.Decimal('inf')`` to accept
         strings of arbitrary length.
         :const:`spyne.server.wsgi.MAX_CONTENT_LENGTH`."""
 
@@ -241,16 +241,16 @@ class Decimal(SimpleModel):
         """Customizable attributes of the :class:`spyne.model.primitive.Decimal`
         type."""
 
-        gt = -float('inf') # minExclusive
+        gt = decimal.Decimal('-inf') # minExclusive
         """The value should be greater than this number."""
 
-        ge = -float('inf') # minInclusive
+        ge = decimal.Decimal('-inf') # minInclusive
         """The value should be greater than or equal to this number."""
 
-        lt =  float('inf') # maxExclusive
+        lt = decimal.Decimal('inf') # maxExclusive
         """The value should be smaller than this number."""
 
-        le =  float('inf') # maxInclusive
+        le = decimal.Decimal('inf') # maxInclusive
         """The value should be smaller than or equal to this number."""
 
         max_str_len = 1024

--- a/spyne/test/protocol/test_json.py
+++ b/spyne/test/protocol/test_json.py
@@ -18,6 +18,7 @@
 #
 
 import json
+import decimal
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -171,7 +172,7 @@ class Test(unittest.TestCase):
 
     def test_multiple_list(self):
         class SomeService(ServiceBase):
-            @srpc(String(max_occurs=float('inf')), _returns=String(max_occurs=float('inf')))
+            @srpc(String(max_occurs=decimal.Decimal('inf')), _returns=String(max_occurs=decimal.Decimal('inf')))
             def some_call(s):
                 return s
 
@@ -190,7 +191,7 @@ class Test(unittest.TestCase):
 
     def test_multiple_dict(self):
         class SomeService(ServiceBase):
-            @srpc(String(max_occurs=float('inf')), _returns=String(max_occurs=float('inf')))
+            @srpc(String(max_occurs=decimal.Decimal('inf')), _returns=String(max_occurs=decimal.Decimal('inf')))
             def some_call(s):
                 return s
 


### PR DESCRIPTION
`float()` usage raises inconsistencies dependent on machine architecture and Python version, particularly when trying to compare with other primitives like Decimal.

**Python 2.6:**

``` python
>>> from decimal import Decimal
>>> Decimal('123.456') < float('inf')
False
>>> hash(Decimal('inf')), hash(float('inf'))
(-1954451676, 314159)
```

**Python 2.7:**

``` python
>>> from decimal import Decimal
>>> Decimal('123.456') < float('inf')
True
>>> hash(Decimal('inf')), hash(float('inf'))
(314159, 314159)
```

... at the minimum, it's currently breaking soft validation.
