### PR TITLE
Made req_env['QUERY_STRING'] support capital letters.

### DIFF
--- a/spyne/server/wsgi.py
+++ b/spyne/server/wsgi.py
@@ -158,7 +158,7 @@ class WsgiApplication(HttpBase):
         return (
             req_env['REQUEST_METHOD'].upper() == 'GET'
             and (
-                   req_env['QUERY_STRING'] == 'wsdl'
+                   req_env['QUERY_STRING'].lower() == 'wsdl'
                 or req_env['PATH_INFO'].endswith('.wsdl')
             )
         )


### PR DESCRIPTION
Some libraries for SOAP client-side does use a capitalised query string like '?WSDL'.
