### PR TITLE
Add Date type support for omitting time

### DIFF
--- a/spyne/model/primitive.py
+++ b/spyne/model/primitive.py
@@ -674,6 +674,7 @@ class Mandatory(object):
     String = String(type_name="mandatory_string", min_occurs=1, nillable=False, min_len=1)
     Unicode = Unicode(type_name="mandatory_string", min_occurs=1, nillable=False, min_len=1)
     Integer = Integer(type_name="mandatory_integer", min_occurs=1, nillable=False)
+    Date = Date(type_name="mandatory_date", min_occurs=1, nillable=False)
     DateTime = DateTime(type_name="mandatory_date_time", min_occurs=1, nillable=False)
     UnsignedInteger = UnsignedInteger(type_name="mandatory_unsigned_integer", min_occurs=1, nillable=False)
     UnsignedLong = UnsignedLong(type_name="mandatory_unsigned_integer", min_occurs=1, nillable=False)


### PR DESCRIPTION
remove argument from isoformat call to make model.primitive.DateTime compatible with datetime.date objects.
insert Date type for getting date without time expression.
