### PR TITLE
Support for using parent class __doc__ for Annotations.doc

### DIFF
--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -58,11 +58,14 @@ def complex_add(document, cls):
     complex_type = etree.Element("{%s}complexType" % _ns_xsd)
     complex_type.set('name', cls.get_type_name())
 
-    if cls.Annotations.doc != '' or cls.Annotations.appinfo != None:
+    if cls.Annotations.doc != '' or cls.Annotations.appinfo != None or cls.Annotations.__use_parent_doc__:
         annotation = etree.SubElement(complex_type, "{%s}annotation" % _ns_xsd)
-        if cls.Annotations.doc != '':
+        if cls.Annotations.doc != '' or cls.Annotations.__use_parent_doc__:
             doc = etree.SubElement(annotation, "{%s}documentation" % _ns_xsd)
-            doc.text = cls.Annotations.doc
+            if cls.Annotations.__use_parent_doc__:
+                doc.text = getattr(cls, '__doc__')
+            else:
+                doc.text = cls.Annotations.doc
 
         _ai = cls.Annotations.appinfo;
         if _ai != None:

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -106,6 +106,10 @@ class ModelBase(object):
     class Annotations(object):
         """The class that holds the annotations for the given type."""
 
+        __use_parent_doc__ = False
+        """If set to True Annotations will use __doc__ from parent,
+        this is convenience option"""
+
         doc = ""
         """The documentation for the given type."""
 


### PR DESCRIPTION
I wanted a more convenient way for annotation docs.
Now I can do:

``` python
class MyComplexModel(ComplexModel):
    class Annotations(ComplexModel.Annotations):
        __use_parent_doc__ = True
```

``` python
class ComplexModel1(MyComplexModel):
  '''This is doc for ComplexModel1
  :param in1: In var 1 
  :param in2: In var 2 
  '''
```

  ... 
