### PR TITLE
[defect/#192] `datetime.datetime` not comparable to `datetime.date`

### DIFF
--- a/spyne/model/primitive.py
+++ b/spyne/model/primitive.py
@@ -29,6 +29,7 @@ import uuid
 import pytz
 import decimal
 import datetime
+import time
 
 import spyne.const.xml_ns
 
@@ -715,7 +716,7 @@ class Date(DateTime):
     @classmethod
     def default_parse(cls, string):
         try:
-            return datetime.datetime.strptime(string, '%Y-%m-%d')
+            return datetime.date(*(time.strptime(string, cls.Attributes.format)[0:3]))
 
         except ValueError:
             raise ValidationError(string)


### PR DESCRIPTION
Parsing `date` types MUST return `date` objects -- not `datetime` -- else
comparing with they're own `cls.Attributes` will throw an exception.

Also adds support for the previously unused `cls.Attributes.format`.
