### PR TITLE
fix typo and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ _trial_temp
 
 # output from examples/stream scripts
 *.ogg
+
+# vim cruft
+*.swp

--- a/spyne/_base.py
+++ b/spyne/_base.py
@@ -430,7 +430,7 @@ class EventManager(object):
 
         :param event_name: The event identifier, indicated by the documentation.
                            Usually, this is a string.
-        :param handler: The method context. Event-related data is conventionally
+        :param ctx: The method context. Event-related data is conventionally
                         stored in ctx.event attribute.
         """
 


### PR DESCRIPTION
1. Fix typo in the comment for file_event()
2. Update .gitignore, add vim cruft.

(This is my first time to contribute to open source project.
If I did some wrong, please let me know.)
