### PR TITLE
Support older django versions (Pull request for Issue #221)

### DIFF
--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -34,6 +34,7 @@ from django.http import HttpResponse
 from spyne.server.wsgi import WsgiApplication
 
 class DjangoApplication(WsgiApplication):
+    """You should use this for regular RPC."""
     def __call__(self, request):
         retval = HttpResponse()
 


### PR DESCRIPTION
I've tried to allow support for various versions of Django. I don't know whether this is the best way to do it though.

Note that StreamingHttpResponse was new in Django 1.5, so I think the current base repo version of the code will only work with Django 1.5 or later.

I've only tested the change with Django 1.2.4.
