### PR TITLE
Fix handling of Decimal.Attributes.fraction_digits

### DIFF
--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -275,12 +275,12 @@ def Tget_range_restriction_tag(T):
         def _get_float_restrictions(restriction, cls):
             if cls.Attributes.fraction_digits != T.Attributes.fraction_digits:
                 elt = etree.SubElement(restriction, '{%s}fractionDigits' % _ns_xs)
-                elt.set('value', cls.Attributes.fraction_digits)
+                elt.set('value', cls.to_string(cls.Attributes.fraction_digits))
 
         def _get_integer_restrictions(restriction, cls):
             if cls.Attributes.total_digits != T.Attributes.total_digits:
                 elt = etree.SubElement(restriction, '{%s}totalDigits' % _ns_xs)
-                elt.set('value', cls.Attributes.total_digits)
+                elt.set('value', cls.to_string(cls.Attributes.total_digits))
 
         if issubclass(T, Integer):
             def _get_additional_restrictions(restriction, cls):


### PR DESCRIPTION
The wrong value was used for setting the fraction_dicits at serialization time. Also the wrong type (int) was used instead of string.
