### PR TITLE
Fixes mandatory types that are different from their default types.

### DIFF
--- a/spyne/model/primitive.py
+++ b/spyne/model/primitive.py
@@ -878,8 +878,8 @@ class Mandatory:
     Duration = Duration(type_name="MandatoryDuration", min_occurs=1, nillable=False)
 
     Decimal = Decimal(type_name="MandatoryDecimal", min_occurs=1, nillable=False)
-    Double = Decimal(type_name="MandatoryDouble", min_occurs=1, nillable=False)
-    Float = Double
+    Double = Double(type_name="MandatoryDouble", min_occurs=1, nillable=False)
+    Float = Float(type_name="MandatoryFloat", min_occurs=1, nillable=False)
 
     Integer = Integer(type_name="MandatoryInteger", min_occurs=1, nillable=False)
     Integer64 = Integer64(type_name="MandatoryLong", min_occurs=1, nillable=False)


### PR DESCRIPTION
As currently configured, the Float type will become xs:decimal in the wsdl.
This fix uses the base types, Double and Float instead of Decimal to declare their
mandatory versions, fixing the inconsistency.
