### PR TITLE
Anydict with float values

### DIFF
--- a/spyne/test/test_util.py
+++ b/spyne/test/test_util.py
@@ -227,7 +227,14 @@ class TestEtreeDict(unittest.TestCase):
         self.assertEqual(tostring(none_value), '<a/>',
             "None should not be rendered in the etree")
         
+        string_value = root_dict_to_etree({'a': 'lol'})
+        self.assertEqual(tostring(string_value), '<a>lol</a>',
+            "A string should be rendered as a string")
         
+        complex_string_value = root_dict_to_etree({'a': {'b': 'lol'}})
+        self.assertEqual(tostring(complex_string_value), '<a><b>lol</b></a>',
+            "A string should be rendered as a string")
+
 
 class TestDictDoc(unittest.TestCase):
     def test_the(self):

--- a/spyne/util/etreeconv.py
+++ b/spyne/util/etreeconv.py
@@ -44,7 +44,7 @@ def root_dict_to_etree(d):
     
     if isinstance(val, dict) or isinstance(val, odict):
         dict_to_etree(val, retval)
-    elif not isinstance(val, collections.Sized):
+    elif not isinstance(val, collections.Sized) or isinstance(val, basestring):
         retval.text=str(val)
     else:
         for a in val:
@@ -62,7 +62,7 @@ def dict_to_etree(d, parent):
         if v is None:
             etree.SubElement(parent, k)
 
-        elif not isinstance(v, collections.Sized):
+        elif not isinstance(v, collections.Sized) or isinstance(v, basestring):
             child = etree.SubElement(parent, k)
             child.text=str(v)
             


### PR DESCRIPTION
At the moment you can not assign a dict containing float values to AnyDict.

```
class Foo(ComplexModel):
    bar = AnyDict

q = Foo(bar={'ggg': 1.0})
# error when redering soap envelope
```

this pull request fixes the issue.
