### PR TITLE
Invalid string formatting in Fault error message

### DIFF
--- a/spyne/protocol/soap/soap11.py
+++ b/spyne/protocol/soap/soap11.py
@@ -72,8 +72,7 @@ def _from_soap(in_envelope_xml, xmlids=None):
                                           namespaces={'e': ns.soap_env})
 
     if len(header_envelope) == 0 and len(body_envelope) == 0:
-        raise Fault('Client.SoapError', 'Soap envelope is empty!' %
-                                                            ns.soap_env)
+        raise Fault('Client.SoapError', 'Soap envelope is empty!')
 
     header=None
     if len(header_envelope) > 0:


### PR DESCRIPTION
Just a quick fix. I think there is no need to include empty envelope in this error message. There would be nice to have a test case for this code, but I have no time right now to write it
