### PR TITLE
order of xml elements in wsdl

### DIFF
--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -152,6 +152,7 @@ class Wsdl11(XmlSchema):
 
         self.port_type_dict = {}
         self.service_elt_dict = {}
+        self.service_elt_list = []
 
         self.root_elt = None
         self.service_elt = None
@@ -182,9 +183,10 @@ class Wsdl11(XmlSchema):
 
         ser = None
         if not service_name in self.service_elt_dict:
-            ser = etree.SubElement(self.root_elt, '{%s}service' % _ns_wsdl)
+            ser = etree.Element('{%s}service' % _ns_wsdl)
             ser.set('name', service_name)
             self.service_elt_dict[service_name] = ser
+            self.service_elt_list.append(ser)
 
         else:
             ser = self.service_elt_dict[service_name]
@@ -242,6 +244,9 @@ class Wsdl11(XmlSchema):
                 cb_binding = self.add_bindings_for_methods(s, root,
                                                    service_name, cb_binding)
 
+        for ser in self.service_elt_list:
+            root.append(ser)
+                
         if self.interface.app.transport is None:
             raise Exception("You must set the 'transport' property of the "
                             "parent 'Application' instance")


### PR DESCRIPTION
I'm suggesting to change the order of the xml elements in the wsdl generated by spyne in the following way:

it currently is
&lt;wsdl:definitions...
...
&lt;wsdl:service...
&lt;wsdl:portType...
&lt;wsdl:binding...
&lt;/wsdl:definitions&gt;

my change makes it
&lt;wsdl:definitions...
...
&lt;wsdl:portType...
&lt;wsdl:binding...
&lt;wsdl:service...
&lt;/wsdl:definitions&gt;

the motivation for the change is that although the xsd for wsdl accepts any order (so there are no actual errors with the wsdl's currently generated by spyne), some tools seem to (wrongly) be less flexible (in particular SAP webserver client)
