### PR TITLE
Fix for bad enum comparison

### DIFF
--- a/spyne/model/enum.py
+++ b/spyne/model/enum.py
@@ -77,7 +77,10 @@ def Enum(*values, **kwargs):
             return hash(self.__value)
 
         def __cmp__(self, other):
-            return isinstance(self, type(other)) and cmp(self.__value, other.__value)
+            if isinstance(self, type(other)):
+                return cmp(self.__value, other.__value)
+            else:
+                return cmp(id(self), id(other))
 
         def __invert__(self):
             return values[maximum - self.__value]


### PR DESCRIPTION
For now the following test works incorrectly with spyne:

``` python
from spyne.model.enum import Enum
Jopa = Enum(u"foo", u"bar", u"baz", type_name='Jopa')
assert Jopa.foo == "XXX"
```

This assert unexpectedly passes. This happens due to incorrect implementation of **cmp** method in spyne.model.Enum:

``` python
return isinstance(self, type(other)) and cmp(self.__value, other.__value) 
```

So for any non-enum instance cmp will return zero that will be treated as sign of equality. Look at http://docs.python.org/2/reference/datamodel.html#object.__cmp__ for details.

The correct solution is to compare with another types by id(). Warning: don't try to just call cmp(this, other), such approach will cause infinite recursion.

Also note that **cmp** method is deprecated in python3 and "rich comparison functions" must be implemented to migrate onto.
