### PR TITLE
custom mapper support

### DIFF
--- a/spyne/util/sqlalchemy.py
+++ b/spyne/util/sqlalchemy.py
@@ -53,7 +53,7 @@ from sqlalchemy.dialects.postgresql.base import PGUuid
 from sqlalchemy.ext.compiler import compiles
 
 from sqlalchemy.orm import relationship
-from sqlalchemy.orm import mapper
+from sqlalchemy.orm.util import class_mapper
 from sqlalchemy.ext.associationproxy import association_proxy
 
 from sqlalchemy.types import UserDefinedType
@@ -657,7 +657,7 @@ def gen_sqla_info(cls, cls_bases=()):
                         setattr(self, child_right_col_name, args[0])
 
                     cls_ = type("_" + cls_name, (object,), {'__init__': _i})
-                    mapper(cls_, child_t)
+                    class_mapper(cls_)(cls_, child_t)
                     props["_" + k] = relationship(cls_)
 
                     # generate association proxy
@@ -831,7 +831,7 @@ def gen_sqla_info(cls, cls_bases=()):
     if inheritance is not _SINGLE:
         mapper_args = (table,) + mapper_args
 
-    cls_mapper = mapper(cls, *mapper_args, **mapper_kwargs)
+    cls_mapper = class_mapper(cls)(cls, *mapper_args, **mapper_kwargs)
 
     def my_load_listener(target, context):
         d = target.__dict__
@@ -904,6 +904,6 @@ def gen_spyne_info(cls):
         mapper_kwargs['include_properties'] = _type_info.keys()
 
     # Map the table to the object
-    cls_mapper = mapper(cls, table, *mapper_args, **mapper_kwargs)
+    cls_mapper = class_mapper(cls)(cls, table, *mapper_args, **mapper_kwargs)
     cls.Attributes.table_name = cls.__tablename__ = table.name
     cls.Attributes.sqla_mapper = cls.__mapper__ = cls_mapper


### PR DESCRIPTION
Sometimes it required to use custom mapper instead of default mapper provided with sqlalchemy. Unfortunately, Spyne was indifferent about and was always using sqlalchemy default mapper. This pull request fixes it.
