### PR TITLE
Fix incorrect wsdl generation with REQUEST_SUFFIX

### DIFF
--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -421,7 +421,7 @@ class Wsdl11(XmlSchema):
 
         def inner(method, binding):
             operation = etree.Element('{%s}operation' % _ns_wsdl)
-            operation.set('name', method.name)
+            operation.set('name', method.operation_name)
 
             soap_operation = etree.SubElement(operation, '{%s}operation'
                                                                     % _ns_soap)

--- a/spyne/test/interface/wsdl/test_op_req_suffix.py
+++ b/spyne/test/interface/wsdl/test_op_req_suffix.py
@@ -159,6 +159,9 @@ class TestOperationRequestSuffix(unittest.TestCase):
         ]
         for soap_string in soap_strings:
             self.assertTrue(soap_string in wsdl, '{0} not in {1}'.format(soap_string, wsdl))
+        if request_name != operation_name:
+            wrong_string = '<wsdl:operation name="{0}"'.format(request_name)
+            self.assertFalse(wrong_string in wsdl, '{0} in {1}'.format(wrong_string, wsdl))
 
         output_name = '<wsdl:output name="{0}Response"'.format(self.default_function_name)
         self.assertTrue(output_name in wsdl, 'REQUEST_SUFFIX or _in_message_name changed the output name, it should be: {0}'.format(output_name))


### PR DESCRIPTION
rkakrik was right, there was a wsdl operation name I missed. I corrected it and updated the tests to check for it.

All tests passed that passed before, double checked that the wsdl works with different clients.
