### PR TITLE
Fixed date parsing when a timezone offset is provided.

### DIFF
--- a/spyne/model/primitive.py
+++ b/spyne/model/primitive.py
@@ -695,6 +695,8 @@ class Date(DateTime):
 
     __type_name__ = 'date'
 
+    _offset_re = re.compile(DATE_PATTERN + '(' + OFFSET_PATTERN + '|Z)')
+
     class Attributes(DateTime.Attributes):
         """Customizable attributes of the :class:`spyne.model.primitive.Date`
         type."""

--- a/spyne/protocol/_model.py
+++ b/spyne/protocol/_model.py
@@ -271,7 +271,11 @@ def date_from_string_iso(cls, string):
     try:
         return datetime.date(*(time.strptime(string, '%Y-%m-%d')[0:3]))
     except ValueError:
-        raise ValidationError(string)
+        match = cls._offset_re.match(string)
+        if match:
+            return datetime.date(int(match.group('year')), int(match.group('month')), int(match.group('day')))
+        else:
+            raise ValidationError(string)
 
 
 @nillable_string
@@ -296,7 +300,11 @@ def date_from_string(cls, string):
         d = datetime.datetime.strptime(string, cls.Attributes.format)
         return datetime.date(d.year, d.month, d.day)
     except ValueError, e:
-        raise ValidationError(string, "%%r: %r" % e)
+        match = cls._offset_re.match(string)
+        if match:
+            return datetime.date(int(match.group('year')), int(match.group('month')), int(match.group('day')))
+        else:
+            raise ValidationError(string, "%%r: %r" % e)
 
 
 if hasattr(datetime.timedelta, 'total_seconds'):

--- a/spyne/test/protocol/test_soap.py
+++ b/spyne/test/protocol/test_soap.py
@@ -31,7 +31,7 @@ from spyne.decorator import rpc
 from spyne.interface.wsdl import Wsdl11
 from spyne.model.complex import Array
 from spyne.model.complex import ComplexModel
-from spyne.model.primitive import DateTime
+from spyne.model.primitive import DateTime, Date
 from spyne.model.primitive import Float
 from spyne.model.primitive import Integer
 from spyne.model.primitive import String
@@ -297,6 +297,14 @@ class TestSoap(unittest.TestCase):
 
         dt = Soap11().from_element(DateTime(format=format), element[0])
         assert n == dt
+
+    def test_date_with_tzoffset(self):
+        for iso_d in ('2013-04-05', '2013-04-05+02:00', '2013-04-05-02:00', '2013-04-05Z'):
+            d = Soap11().from_string(Date, iso_d)
+            assert isinstance(d, datetime.date) == True
+            assert d.year == 2013
+            assert d.month == 4
+            assert d.day == 5
 
     def test_to_parent_element_nested(self):
         m = ComplexModel.produce(

--- a/spyne/test/protocol/test_xml.py
+++ b/spyne/test/protocol/test_xml.py
@@ -23,6 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 import unittest
 import decimal
+import datetime
 
 from pprint import pprint
 
@@ -37,6 +38,7 @@ from spyne.decorator import srpc
 from spyne.model.primitive import Integer
 from spyne.model.primitive import Decimal
 from spyne.model.primitive import Unicode
+from spyne.model.primitive import Date
 from spyne.model.complex import XmlData
 from spyne.model.complex import ComplexModel
 from spyne.model.complex import XmlAttribute
@@ -297,6 +299,16 @@ class TestXml(unittest.TestCase):
         assert c.c == 3
         assert c.d == 4
 
+    def test_dates(self):
+        d = Date
+        xml_dates = [etree.fromstring('<d>2013-04-05</d>'), etree.fromstring('<d>2013-04-05+02:00</d>'), etree.fromstring('<d>2013-04-05-02:00</d>'), etree.fromstring('<d>2013-04-05Z</d>')]
+        for xml_date in xml_dates:
+            c = get_xml_as_object(xml_date, d)
+            assert isinstance(c, datetime.date) == True
+            assert c.year == 2013
+            assert c.month == 4
+            assert c.day == 5
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Here's a proposed fix for issue #287 I created earlier.

If a value error occurs as a result of passing the date string into strptime, check regex to see if it matches a dateformat with a timezone offset.  If it matches, create a date object with the captured year, month, and day components.

I've included unit test cases for both XML and SOAP parsing.
