### PR TITLE
Programmer control of sequence declaration in WSDL

### DIFF
--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -77,11 +77,32 @@ class AttributesMeta(type(object)):
     nillable = property(get_nillable, set_nillable)
 
 
+class ModelBaseMeta(type):
+    """Meta class for spyne.model.ModelBase.  It's sole job in life to
+    to record the order instances of spyne.modem.ModelBase and it's subclasses
+    are created.  This allows spyne.model.complex.ComplexModelBase to
+    create a WSDL with class members in the same order they were declared
+    in Python"""
+
+    __order = 0
+
+    def __new__(cls, name, bases, dct):
+        dct["__declare_order__"] = cls.declare_ordering()
+        return super(ModelBaseMeta, cls).__new__(cls, name, bases, dct)
+
+    @classmethod
+    def declare_ordering(cls):
+        ModelBaseMeta.__order += 1
+        return ModelBaseMeta.__order
+
+
 class ModelBase(object):
     """The base class for type markers. It defines the model interface for the
     interface generators to use and also manages class customizations that are
     mainly used for defining constraints on input values.
     """
+
+    __metaclass__ = ModelBaseMeta
 
     __orig__ = None
     """This holds the original class the class .customize()d from. Ie if this is
@@ -99,6 +120,11 @@ class ModelBase(object):
     __type_name__ = None
     """The public type name of the class. Use ``get_type_name()`` instead of
     accessing it directly."""
+
+    __declare_order__ = None
+    """The number of Models created so far.  In other words this can be used
+    to determine the order subclasses and instances of sypne.model.ModelBase
+    are created."""
 
     # These are not the xml schema defaults. The xml schema defaults are
     # considered in XmlSchema's add() method. the defaults here are to reflect

--- a/spyne/test/model/test_complex.py
+++ b/spyne/test/model/test_complex.py
@@ -102,6 +102,16 @@ class Level1(ComplexModel):
 
 Level1.resolve_namespace(Level1, __name__)
 
+class DeclareOrder_name(ComplexModel.customize(declare_order='name')):
+    field3 = Integer()
+    field1 = Integer()
+    field2 = Integer()
+
+class DeclareOrder_declare(ComplexModel.customize(declare_order='declared')):
+    field3 = Integer()
+    field1 = Integer()
+    field2 = Integer()
+
 class TestComplexModel(unittest.TestCase):
     def test_add_field(self):
         class C(ComplexModel):
@@ -314,6 +324,10 @@ class TestComplexModel(unittest.TestCase):
         self.assertEquals(Derived.Attributes.prop1, Base.Attributes.prop1)
         self.assertNotEquals(Derived2.Attributes.prop1, Base.Attributes.prop1)
         self.assertEquals(Derived3.Attributes.prop1, Base.Attributes.prop1)
+
+    def test_declare_order(self):
+        self.assertEquals(["field1", "field2", "field3"], list(DeclareOrder_name._type_info))
+        self.assertEquals(["field3", "field1", "field2"], list(DeclareOrder_declare._type_info))
 
 
 


### PR DESCRIPTION
I have been bitten once again by me changing something apparently innocuous in my type definitions (adding a nillable I think), and then breaking every client that generates compiled code from the WSDL.  (This means just about everyone who doesn't use python-suds).

We have discussed before: https://github.com/arskom/spyne/issues/233#issuecomment-18737172

So, here is a patch that fixes it - at the expense of breaking all existing servers in this way one final time, of course.

The patch works by automagically assigning every subclass of ModelBase a unique number called **declare_order**.  The number is incremented each time a new subclass is created.

ComplexModelBase inserts fields into _type_info in ascending order of __declare_order__.  The WSDL already generated it's sequence in the order things were put into _type_info, so if you create a new type for every field in a ComplexModel like this:

``` python
class MyStruct(ComplexModel):
  y = Unicode()
  x = Double()
```

Then the WSDL generated by Spyne will match the declared order of the fields in Python (ie y will be declared then x) - like just about every other SOAP implementation on the planet.  

If you don't generate new types then the fallback is to use the names.  So in this case in the WSDL x would be declared before y, because that is the sort order of the names.  Not perfect, but it will be stable across revisions of Spyne, and python.
