### PR TITLE
Tried to reproduce bug with empty array

### DIFF
--- a/examples/django/rpctest/core/views.py
+++ b/examples/django/rpctest/core/views.py
@@ -34,7 +34,7 @@ from django.views.decorators.csrf import csrf_exempt
 from spyne.error import ResourceNotFoundError, ResourceAlreadyExistsError
 from spyne.server.django import DjangoApplication
 from spyne.model.primitive import Unicode, Integer
-from spyne.model.complex import Iterable
+from spyne.model.complex import Iterable, Array
 from spyne.service import ServiceBase
 from spyne.protocol.soap import Soap11
 from spyne.application import Application
@@ -71,6 +71,10 @@ class ContainerService(ServiceBase):
             return FieldContainer.objects.create(**container.as_dict())
         except IntegrityError:
             raise ResourceAlreadyExistsError('Container')
+
+    @rpc(_returns=Array(FieldContainer))
+    def get_containers(ctx):
+        return FieldContainer.objects.all()
 
 app = Application([HelloWorldService, ContainerService],
     'spyne.examples.django',

--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -95,3 +95,8 @@ class ModelTestCase(TestCase):
         c = create_container()
         self.assertIsInstance(c, Container)
         self.assertRaises(Fault, create_container)
+
+    def test_get_containers(self):
+        """Regression test for empty array."""
+        hello_array = self.client.service.get_containers()
+        self.assertEqual(len(hello_array), 0)

--- a/spyne/util/django.py
+++ b/spyne/util/django.py
@@ -11,6 +11,7 @@ from django.core.validators import (email_re, slug_re,
                                     comma_separated_int_list_re, URLValidator)
 from spyne.model.complex import ComplexModelMeta, ComplexModelBase
 from spyne.model import primitive
+from spyne.util.six import add_metaclass
 
 
 logger = logging.getLogger(__name__)
@@ -272,8 +273,9 @@ class DjangoComplexModelMeta(ComplexModelMeta):
         return super_new(mcs, name, bases, spyne_attrs)
 
 
-@add_metaclasss(DjangoComplexModelMeta)
+@add_metaclass(DjangoComplexModelMeta)
 class DjangoComplexModel(ComplexModelBase):
+
     """Base class with Django model mapping support.
 
     Sample usage: ::


### PR DESCRIPTION
Tried to reproduce bug with empty array on master but got following traceback:

```
File "examples/django/rpctest/manage.py", line 43, in <module>
    execute_manager(settings)
  File "/ENV/lib/python2.7/site-packages/django/core/management/__init__.py", line 459, in execute_manager
    utility.execute()
  File "/ENV/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/ENV/lib/python2.7/site-packages/django/core/management/commands/test.py", line 49, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/ENV/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/ENV/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/ENV/lib/python2.7/site-packages/django/core/management/commands/test.py", line 72, in handle
    failures = test_runner.run_tests(test_labels)
  File "/ENV/lib/python2.7/site-packages/django/test/simple.py", line 380, in run_tests
    suite = self.build_suite(test_labels, extra_tests)
  File "/ENV/lib/python2.7/site-packages/django/test/simple.py", line 267, in build_suite
    suite.addTest(build_suite(app))
  File "/ENV/lib/python2.7/site-packages/django/test/simple.py", line 79, in build_suite
    test_module = get_tests(app_module)
  File "/ENV/lib/python2.7/site-packages/django/test/simple.py", line 36, in get_tests
    test_module = import_module('.'.join(prefix + [TEST_MODULE]))
  File "/ENV/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/home/srk/workspace/spyne/examples/django/rpctest/core/tests.py", line 30, in <module>
    from rpctest.core.views import app, hello_world_service, Container
  File "/home/srk/workspace/spyne/examples/django/rpctest/core/views.py", line 60, in <module>
    class ContainerService(ServiceBase):
  File "/home/srk/workspace/spyne/examples/django/rpctest/core/views.py", line 75, in ContainerService
    @rpc(_returns=Array(FieldContainer))
  File "/home/srk/workspace/spyne/spyne/model/complex.py", line 977, in __new__
    raise ValueError(serializer)
ValueError: None
```
