### PR TITLE
Couldn't pass unicode strings without declared encoding

### DIFF
--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 #!/usr/bin/env python
 #
 # spyne - Copyright (C) Spyne contributors.
@@ -90,6 +91,22 @@ class ModelTestCase(TestCase):
                                        date_field=datetime.date.today(),
                                        datetime_field=datetime.datetime.now(),
                                        time_field=datetime.time())
+        create_container = (lambda: self.client.service.create_container(
+            new_container))
+        c = create_container()
+        self.assertIsInstance(c, Container)
+        self.assertRaises(Fault, create_container)
+
+    def test_create_container_unicode(self):
+        """Test complex unicode input to create Django model."""
+        new_container = FieldContainer(
+            char_field=u'спайн',
+            text_field=u'спайн',
+            slug_field=u'спайн',
+            date_field=datetime.date.today(),
+            datetime_field=datetime.datetime.now(),
+            time_field=datetime.time()
+        )
         create_container = (lambda: self.client.service.create_container(
             new_container))
         c = create_container()

--- a/spyne/util/django.py
+++ b/spyne/util/django.py
@@ -219,18 +219,18 @@ def strip_regex_metachars(pattern):
 DEFAULT_FIELD_MAP = (
     ('AutoField', primitive.Integer32),
     ('CharField', primitive.NormalizedString),
-    ('SlugField', primitive.String(
+    ('SlugField', primitive.Unicode(
         type_name='Slug', pattern=strip_regex_metachars(slug_re.pattern))),
-    ('TextField', primitive.String),
-    ('EmailField', primitive.String(
+    ('TextField', primitive.Unicode),
+    ('EmailField', primitive.Unicode(
         type_name='Email', pattern=strip_regex_metachars(email_re.pattern))),
-    ('CommaSeparatedIntegerField', primitive.String(
+    ('CommaSeparatedIntegerField', primitive.Unicode(
         type_name='CommaSeparatedField',
         pattern=strip_regex_metachars(comma_separated_int_list_re.pattern))),
     ('UrlField', primitive.AnyUri(
         type_name='Url',
         pattern=strip_regex_metachars(URLValidator.regex.pattern))),
-    ('FilePathField', primitive.String),
+    ('FilePathField', primitive.Unicode),
 
     ('BooleanField', primitive.Boolean),
     ('NullBooleanField', primitive.Boolean),


### PR DESCRIPTION
Text fields are mapped to primitive.Unicode as more usable type.
