### PR TITLE
Fixed wrong test test and unicode issue

### DIFF
--- a/spyne/protocol/xml.py
+++ b/spyne/protocol/xml.py
@@ -320,8 +320,10 @@ class XmlDocument(SubXmlBase):
 
         logger.debug("Validated ? %s" % str(ret))
         if ret == False:
-            raise SchemaValidationError(
-                               str(self.validation_schema.error_log.last_error))
+            error_text = unicode(self.validation_schema.error_log.last_error)
+
+            raise SchemaValidationError(error_text.encode('ascii',
+                                                          'xmlcharrefreplace'))
 
     def create_in_document(self, ctx, charset=None):
         """Uses the iterable of string fragments in ``ctx.in_string`` to set

--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -105,12 +105,12 @@ class ModelTestCase(TestCase):
         self.assertIsInstance(c, Container)
         self.assertRaises(Fault, create_container)
 
-    def _test_create_container_unicode(self):
+    def test_create_container_unicode(self):
         """Test complex unicode input to create Django model."""
         new_container = FieldContainer(
             char_field=u'спайн',
             text_field=u'спайн',
-            slug_field=u'спайн',
+            slug_field='spyne',
             date_field=datetime.date.today(),
             datetime_field=datetime.datetime.now(),
             time_field=datetime.time()


### PR DESCRIPTION
This pull request fixes https://github.com/arskom/spyne/issues/339 and https://github.com/arskom/spyne/issues/326

It looks like Django>=1.5 has more strict validation of slug fields.
