### PR TITLE
wsdl caching doesn't allow to serve service on several locations

### DIFF
--- a/examples/django/rpctest/urls.py
+++ b/examples/django/rpctest/urls.py
@@ -39,5 +39,9 @@ urlpatterns = patterns('',
     url(r'^say_hello/', DjangoView.as_view(
         services=[HelloWorldService], tns='spyne.examples.django',
         in_protocol=Soap11(validator='lxml'), out_protocol=Soap11())),
+    url(r'^say_hello_not_cached/', DjangoView.as_view(
+        services=[HelloWorldService], tns='spyne.examples.django',
+        in_protocol=Soap11(validator='lxml'), out_protocol=Soap11(),
+        cache_wsdl=False)),
     url(r'^api/', DjangoView.as_view(application=app)),
 )

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -106,9 +106,10 @@ class StreamingDjangoApplication(DjangoApplication):
 class DjangoServer(HttpBase):
     """Server talking in Django request/response objects."""
 
-    def __init__(self, app, chunked=False):
+    def __init__(self, app, chunked=False, cache_wsdl=True):
         super(DjangoServer, self).__init__(app, chunked=chunked)
         self._wsdl = None
+        self._cache_wsdl = cache_wsdl
 
     def handle_rpc(self, request, *args, **kwargs):
         """Handle rpc request.
@@ -173,10 +174,16 @@ class DjangoServer(HttpBase):
             # create and build interface documents in current thread. This
             # section can be safely repeated in another concurrent thread.
             doc = AllYourInterfaceDocuments(self.app.interface)
-            doc.wsdl11.build_interface_document(request.build_absolute_uri())
-            self._wsdl = doc.wsdl11.get_interface_document()
+            doc.wsdl11.build_interface_document(
+                request.build_absolute_uri())
+            wsdl = doc.wsdl11.get_interface_document()
 
-        ctx.transport.wsdl = self._wsdl
+            if self._cache_wsdl:
+                self._wsdl = wsdl
+        else:
+            wsdl = self._wsdl
+
+        ctx.transport.wsdl = wsdl
         ctx.close()
 
         response = HttpResponse(ctx.transport.wsdl)
@@ -251,6 +258,7 @@ class DjangoView(object):
     out_protocol = Soap11()
     interface = None
     chunked = False
+    cache_wsdl = True
 
     http_method_names = ['get', 'post', 'put', 'patch', 'delete', 'head',
                          'options', 'trace']
@@ -281,7 +289,9 @@ class DjangoView(object):
                                 "attributes of the class." % (cls.__name__,
                                                               key))
 
-        get = lambda key: initkwargs.get(key) or getattr(cls, key)
+        def get(key):
+            value = initkwargs.get(key)
+            return value if value is not None else getattr(cls, key)
 
         application = get('application') or Application(
             services=get('services'),
@@ -292,7 +302,8 @@ class DjangoView(object):
             interface=get('interface')
         )
         server = get('server') or DjangoServer(application,
-                                               chunked=get('chunked'))
+                                               chunked=get('chunked'),
+                                               cache_wsdl=get('cache_wsdl'))
 
         def view(request, *args, **kwargs):
             self = cls(server=server, **initkwargs)

--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -63,12 +63,27 @@ class DjangoViewTestCase(TestCase):
         response = client.post('/say_hello/', {})
         self.assertContains(response, 'faultstring', status_code=500)
 
-    def test_wsdl(self):
+    def test_cached_wsdl(self):
+        """Test if wsdl is cached."""
         client = Client()
         response = client.get('/say_hello/')
         self.assertContains(response,
                             'location="http://testserver/say_hello/"')
+        response = client.get('/say_hello/', HTTP_HOST='newtestserver')
+        self.assertNotContains(response,
+                            'location="http://newtestserver/say_hello/"')
 
+    def test_not_cached_wsdl(self):
+        """Test if wsdl is not cached."""
+        client = Client()
+        response = client.get('/say_hello_not_cached/')
+        self.assertContains(
+            response, 'location="http://testserver/say_hello_not_cached/"')
+        response = client.get('/say_hello_not_cached/',
+                              HTTP_HOST='newtestserver')
+
+        self.assertContains(
+            response, 'location="http://newtestserver/say_hello_not_cached/"')
 
 class ModelTestCase(TestCase):
 


### PR DESCRIPTION
Can't serve DjangoServer on several locations due to cached WSDL. Service location is determined from request headers. At the moment WSDL location is bound to location from the first request.

Building of wsdl document is cheap. No need for caching.
