### PR TITLE
customizable exception string

### DIFF
--- a/spyne/application.py
+++ b/spyne/application.py
@@ -90,11 +90,13 @@ class Application(object):
     transport = None
 
     def __init__(self, services, tns, name=None,
-                          in_protocol=None, out_protocol=None, config=None):
+                          in_protocol=None, out_protocol=None, config=None,
+                                                      exception_detail=False):
         self.services = tuple(services)
         self.tns = tns
         self.name = name
         self.config = config
+        self.exception_detail = exception_detail
 
         if self.name is None:
             self.name = self.__class__.__name__.split('.')[-1]
@@ -172,7 +174,8 @@ class Application(object):
         except Exception as e:
             logger.exception(e)
 
-            ctx.out_error = Fault('Server', get_fault_string_from_exception(e))
+            ctx.out_error = Fault('Server',
+                                  self.get_fault_string_from_exception(e))
 
             # fire events
             self.event_manager.fire_event('method_exception_object', ctx)
@@ -256,3 +259,9 @@ class Application(object):
 
     def __hash__(self):
         return hash(tuple((id(s) for s in self.services)))
+
+    def get_fault_string_from_exception(self, e):
+        if self.exception_detail:
+            return unicode(e).encode('ascii', 'xmlcharrefreplace')
+
+        return get_fault_string_from_exception(e)

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -39,7 +39,7 @@ except ImportError as e:
     def StreamingHttpResponse(*args, **kwargs):
         raise e
 
-from spyne.application import get_fault_string_from_exception, Application
+from spyne.application import Application
 from spyne.auxproc import process_contexts
 from spyne.interface import AllYourInterfaceDocuments
 from spyne.model.fault import Fault
@@ -140,7 +140,7 @@ class DjangoServer(HttpBase):
         except Exception as e:
             logger.exception(e)
             p_ctx.out_error = Fault('Server',
-                                    get_fault_string_from_exception(e))
+                                    self.app.get_fault_string_from_exception(e))
             return self.handle_error(p_ctx, others, p_ctx.out_error)
 
         have_protocol_headers = (isinstance(p_ctx.out_protocol, HttpRpc) and

--- a/spyne/server/wsgi.py
+++ b/spyne/server/wsgi.py
@@ -45,7 +45,6 @@ else:
     from Cookie import SimpleCookie
 
 
-from spyne.application import get_fault_string_from_exception
 from spyne.auxproc import process_contexts
 from spyne.error import RequestTooLongError
 from spyne.model.binary import File
@@ -357,7 +356,8 @@ class WsgiApplication(HttpBase):
 
         except Exception as e:
             logger.exception(e)
-            p_ctx.out_error = Fault('Server', get_fault_string_from_exception(e))
+            p_ctx.out_error = Fault('Server',
+                                    self.app.get_fault_string_from_exception(e))
             return self.handle_error(p_ctx, others, p_ctx.out_error,
                                                                  start_response)
 


### PR DESCRIPTION
Hello.
Spyne returns "Internal Error" on any unhandled exception now.
I propose to make it customizable. It will be useful when all clients are yours and you do not need to worry about security.
