### PR TITLE
soap12: fix namespaces (no final slash)

### DIFF
--- a/spyne/const/xml_ns.py
+++ b/spyne/const/xml_ns.py
@@ -31,8 +31,8 @@ xhtml = 'http://www.w3.org/1999/xhtml'
 plink = 'http://schemas.xmlsoap.org/ws/2003/05/partner-link/'
 soap11_enc = 'http://schemas.xmlsoap.org/soap/encoding/'
 soap11_env = 'http://schemas.xmlsoap.org/soap/envelope/'
-soap12_env = 'http://www.w3.org/2003/05/soap-envelope/'
-soap12_enc = 'http://www.w3.org/2003/05/soap-encoding/'
+soap12_env = 'http://www.w3.org/2003/05/soap-envelope'
+soap12_enc = 'http://www.w3.org/2003/05/soap-encoding'
 
 const_nsmap = {
     'xml': xml,


### PR DESCRIPTION
According to http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383492
SOAP 1.1 namespaces are:
 - http://schemas.xmlsoap.org/soap/envelope/
 - http://schemas.xmlsoap.org/soap/encoding/
(with final slash)

But according to http://www.w3.org/TR/soap12-part1/#soapenvelope
SOAP 1.2 namespaces are:
 - http://www.w3.org/2003/05/soap-envelope
 - http://www.w3.org/2003/05/soap-encoding
(no final slash)