### PR TITLE
exclude TLDs from valid emails

### DIFF
--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -260,6 +260,10 @@ class EmailRegexTestCase(TestCase):
         """Test invalid email."""
         self.assertIsNone(re.match(email_re, '@example.com'))
 
+    def test_invalid_tld(self):
+        """Test if email from Top Level Domain is invalid."""
+        self.assertIsNone(re.match(email_re, 'babushka@email'))
+
 
 class DjangoServiceTestCase(TestCase):
 

--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -244,25 +244,35 @@ class ModelTestCase(TestCase):
             assert False, 'Can create non abstract custom model'
 
 
+# in XmlSchema ^ and $ are set implicitly
+python_email_re = '^' + email_re.pattern + '$'
+
+
 class EmailRegexTestCase(TestCase):
 
     """Tests for email_re."""
 
     def test_empty(self):
         """Empty string is invalid email."""
-        self.assertIsNone(re.match(email_re, ''))
+        self.assertIsNone(re.match(python_email_re, ''))
 
     def test_valid(self):
         """Test valid email."""
-        self.assertIsNotNone(re.match(email_re, 'valid.email@example.com'))
+        self.assertIsNotNone(re.match(python_email_re,
+                                      'valid.email@example.com'))
+
+    def test_valid_single_letter_domain(self):
+        """Test valid email."""
+        self.assertIsNotNone(re.match(python_email_re, 'valid.email@e.x.com'))
 
     def test_invalid(self):
         """Test invalid email."""
-        self.assertIsNone(re.match(email_re, '@example.com'))
+        self.assertIsNone(re.match(python_email_re, '@example.com'))
 
     def test_invalid_tld(self):
         """Test if email from Top Level Domain is invalid."""
-        self.assertIsNone(re.match(email_re, 'babushka@email'))
+        self.assertIsNone(re.match(python_email_re, 'babushka@email'))
+        self.assertIsNone(re.match(python_email_re, 'babushka@domain.email-'))
 
 
 class DjangoServiceTestCase(TestCase):

--- a/spyne/util/django.py
+++ b/spyne/util/django.py
@@ -50,7 +50,9 @@ from spyne.util.six import add_metaclass
 email_re = re.compile(
     r"[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
     r"(\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+)*@"
+    # domain should contain at least 2 parts
     r"[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
+    r"\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
     r"(\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+)*", re.IGNORECASE)
 
 

--- a/spyne/util/django.py
+++ b/spyne/util/django.py
@@ -50,10 +50,14 @@ from spyne.util.six import add_metaclass
 email_re = re.compile(
     r"[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
     r"(\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+)*@"
-    # domain should contain at least 2 parts
-    r"[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
-    r"\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+"
-    r"(\.[A-Za-z0-9!#-'\*\+\-/=\?\^_`\{-~]+)*", re.IGNORECASE)
+    # domain part is either a single symbol
+    r"(([a-zA-Z0-9]|"
+    # or have at least two symbols
+    # hyphen can't be at the beginning or end of domain part
+    # domain should contain at least 2 parts, the last one is TLD
+    r"(([a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])+))\.)+"
+    # TLD should contain only letters, at least 2
+    r"[A-Za-z]{2,}", re.IGNORECASE)
 
 
 def _handle_minlength(validator, params):

--- a/spyne/util/django.py
+++ b/spyne/util/django.py
@@ -55,7 +55,7 @@ email_re = re.compile(
     # or have at least two symbols
     # hyphen can't be at the beginning or end of domain part
     # domain should contain at least 2 parts, the last one is TLD
-    r"(([a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])+))\.)+"
+    r"([a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])+)\.)+"
     # TLD should contain only letters, at least 2
     r"[A-Za-z]{2,}", re.IGNORECASE)
 


### PR DESCRIPTION
This PR makes email pattern more strict. Now emails from top level domains (TLDs) are considered invalid. I.e. `about@me` is invalid email.

Updated regex: `about@example.com-` is also invalid