### PR TITLE
Allow defaults to be applied in a JSON document

### DIFF
--- a/spyne/protocol/dictdoc.py
+++ b/spyne/protocol/dictdoc.py
@@ -618,6 +618,11 @@ class HierDictDocument(DictDocument):
             raise ValidationError((key, inst))
 
     def _from_dict_value(self, key, cls, inst, validator):
+        
+        if value is None and hasattr(class_.Attributes, 'default'):
+            value = class_.Attributes.default
+            return value
+        
         if validator is self.SOFT_VALIDATION:
             self.validate(key, cls, inst)
 

--- a/spyne/protocol/dictdoc.py
+++ b/spyne/protocol/dictdoc.py
@@ -619,9 +619,9 @@ class HierDictDocument(DictDocument):
 
     def _from_dict_value(self, key, cls, inst, validator):
         
-        if value is None and hasattr(class_.Attributes, 'default'):
-            value = class_.Attributes.default
-            return value
+        if inst is None and hasattr(cls.Attributes, 'default'):
+            inst = cls.Attributes.default
+            return inst
         
         if validator is self.SOFT_VALIDATION:
             self.validate(key, cls, inst)


### PR DESCRIPTION
When using default values on complexmodels in soap, the defaults are applied correctly and hence validation is passed, but when using json documents with a 'soft' validation, they are not applied, causing the validation to fail.

This change checks if a default is available, and if the attribute is not set. If so, the default is applied. 