### PR TITLE
Spyne in Google App Engine.

### DIFF
--- a/spyne/protocol/_base.py
+++ b/spyne/protocol/_base.py
@@ -34,7 +34,11 @@ from datetime import timedelta, time, datetime, date
 from math import modf
 from decimal import Decimal as D, InvalidOperation
 from pytz import FixedOffset
-from mmap import mmap, ACCESS_READ
+try:
+    from mmap import mmap, ACCESS_READ
+except ImportError:
+    ACCESS_READ = None
+    mmap = None
 from time import strptime, mktime
 from weakref import WeakKeyDictionary
 
@@ -864,6 +868,7 @@ class ProtocolBase(object):
                 assert isinstance(value.handle, file)
 
                 fileno = value.handle.fileno()
+                assert mmap is not None, "Mmap is not supported"
                 data = mmap(fileno, 0, access=ACCESS_READ)
 
                 return binary_encoding_handlers[encoding](data)
@@ -890,6 +895,7 @@ class ProtocolBase(object):
 
     def file_to_string_iterable(self, cls, value):
         if value.data is not None:
+            assert mmap is not None, "Mmap is not supported"
             if isinstance(value.data, (list, tuple)) and \
                     isinstance(value.data[0], mmap):
                 return _file_to_iter(value.data[0])

--- a/spyne/server/twisted/http.py
+++ b/spyne/server/twisted/http.py
@@ -48,7 +48,10 @@ logger = logging.getLogger(__name__)
 import re
 
 from os import fstat
-from mmap import mmap
+try:
+    from mmap import mmap
+except ImportError:
+    mmap = None
 from inspect import isgenerator, isclass
 from collections import namedtuple
 
@@ -375,6 +378,7 @@ class TwistedWebResource(Resource):
             if fstat(f.fileno()).st_size == 0:
                 initial_ctx.in_string = ['']
             else:
+                assert mmap is not None, "Mmap is not supported"
                 initial_ctx.in_string = [mmap(f.fileno(), 0)]
         else:
             request.content.seek(0)


### PR DESCRIPTION
Recently I had to include SOAP service within Django app that was running in Google App Engine. There aren't many good SOAP libraries for python and even fewer work within the GAE sandbox. Spyne seems to be the best library out there, so I decided to try to modify it to work inside the GAE sandbox. Fortunately, it didn't require too many changes to the library.

Python module [mmap](https://docs.python.org/2/library/mmap.html) is not supported inside [GAE](https://cloud.google.com/appengine/), therefore added a catch for the ImportError and an assert upon [mmap](https://docs.python.org/2/library/mmap.html) usage.
Also, refactored build_validation_schema to use [memcache](https://cloud.google.com/appengine/docs/python/memcache/) and StringIO when tempfile.mkdtemp raises NotImplementedError.
(In GAE, [tempfile.TemporaryFile](https://cloud.google.com/appengine/docs/python/#Python_The_sandbox) is an alias for StringIO)

Tested with [helloworld soap example](https://github.com/arskom/spyne/blob/master/examples/helloworld_soap.py) with normal WSGI app and  Django. 
