### PR TITLE
Fixes from_unicode and from_string

### DIFF
--- a/spyne/protocol/_inbase.py
+++ b/spyne/protocol/_inbase.py
@@ -217,11 +217,11 @@ class InProtocolBase(ProtocolMixin):
         self.validator = None
 
     def from_string(self, class_, string, *args, **kwargs):
-        if six.PY3:
-            assert isinstance(string, bytes)
-
         if string is None:
             return None
+
+        if six.PY3:
+            assert isinstance(string, bytes)
 
         if isinstance(string, six.string_types) and \
                            len(string) == 0 and class_.Attributes.empty_is_none:
@@ -231,11 +231,11 @@ class InProtocolBase(ProtocolMixin):
         return handler(class_, string, *args, **kwargs)
 
     def from_unicode(self, class_, string, *args, **kwargs):
-        if six.PY3:
-            assert isinstance(string, str)
-
         if string is None:
             return None
+
+        if six.PY3:
+            assert isinstance(string, str)
 
         if isinstance(string, six.string_types) and len(string) == 0 and \
                                                 class_.Attributes.empty_is_none:

--- a/spyne/test/interop/test_django.py
+++ b/spyne/test/interop/test_django.py
@@ -290,3 +290,17 @@ class DjangoServiceTestCase(TestCase):
         client = DjangoTestClient('/api/', app)
         with self.assertRaisesRegexp(Fault, 'Client.ValidationError'):
             client.service.raise_validation_error()
+
+
+class FromUnicodeAssertionTestCase(TestCase):
+
+    def test_from_unicode_does_not_assert(self):
+        client = Client()
+        url = '/synchro/1/'
+        msg = b"""<?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/
+            soap/envelope/"xmlns:ns1="tns" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="
+            http://www.w3.org/2001/XMLSchema-instance"><SOAP-ENV:Header/><ns0:Body><ns1:sync><ns1:model_id>TestModel
+            </ns1:model_id><ns1:timestamp>2015-09-23T13:54:51.796366+00:00</ns1:timestamp><ns1:payload>
+            </ns1:payload><ns1:partial/></ns1:sync></ns0:Body></SOAP-ENV:Envelope>"""
+        hdrs = {'SOAPAction': b'"sync"', 'Content-Type': 'text/xml; charset=utf-8'}
+        client.post(url, msg, 'text/xml', True, **hdrs)


### PR DESCRIPTION
The `if string is None` test should be first, since `from_string` and `from_unicode` may be called with string=None in some cases (e.g. request in the unit test)