### PR TITLE
Remove gc.collect calls that kills spyne's perf

### DIFF
--- a/spyne/_base.py
+++ b/spyne/_base.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 #
 
-import gc, logging
+import logging
 logger = logging.getLogger(__name__)
 
 from time import time
@@ -382,9 +382,6 @@ class MethodContext(object):
             f.close()
 
         self.is_closed = True
-
-        # this is important to have file descriptors returned in a timely manner
-        gc.collect()
 
     def set_out_protocol(self, what):
         self._out_protocol = what


### PR DESCRIPTION
For a simple WS like:

    class HealthZWebService(ws_spyne.TransactionalServiceBase):
        @srpc(_returns=Boolean.customize(min_occurs=1, max_occurs=1, nillable=False))
        def ping():
            return True

With vanilla v2.12.10 (and gc.collect) the pstats gives:

    gc.sort_stats('cumtime').print_stats(20)
    Thu Oct 29 14:31:41 2015    ./spyne2.12_with_gc
    
             209059 function calls (205448 primitive calls) in 7.959 seconds
    
       Ordered by: cumulative time
       List reduced from 567 to 20 due to restriction <20>
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
          100    0.000    0.000    7.955    0.080 venv/local/lib/python2.7/site-packages/suds/client.py:530(__call__)
          100    0.001    0.000    7.952    0.080 venv/local/lib/python2.7/site-packages/suds/client.py:581(invoke)
          100    0.004    0.000    7.930    0.079 venv/local/lib/python2.7/site-packages/suds/client.py:610(send)
          100    0.001    0.000    7.844    0.078 venv/local/lib/python2.7/site-packages/bluetils/ws/suds_test.py:129(send)
          100    0.001    0.000    7.841    0.078 venv/local/lib/python2.7/site-packages/django/test/client.py:478(post)
          100    0.001    0.000    7.840    0.078 venv/local/lib/python2.7/site-packages/django/test/client.py:282(post)
          100    0.002    0.000    7.834    0.078 venv/local/lib/python2.7/site-packages/django/test/client.py:407(request)
          100    0.002    0.000    7.824    0.078 venv/local/lib/python2.7/site-packages/django/test/client.py:92(__call__)
          100    0.002    0.000    7.805    0.078 venv/local/lib/python2.7/site-packages/django/core/handlers/base.py:74(get_response)
          100    0.001    0.000    7.789    0.078 venv/local/lib/python2.7/site-packages/viewsgi.py:39(view)
          100    0.001    0.000    7.779    0.078 venv/local/lib/python2.7/site-packages/spyne/server/wsgi.py:229(__call__)
          100    0.003    0.000    7.776    0.078 venv/local/lib/python2.7/site-packages/spyne/server/wsgi.py:341(handle_rpc)
          100    0.001    0.000    7.647    0.076 venv/local/lib/python2.7/site-packages/spyne/server/wsgi.py:446(__finalize)
          100    0.001    0.000    7.645    0.076 venv/local/lib/python2.7/site-packages/spyne/_base.py:378(close)
          100    7.644    0.076    7.644    0.076 {gc.collect}
          100    0.002    0.000    0.067    0.001 venv/local/lib/python2.7/site-packages/suds/client.py:674(succeeded)
          100    0.003    0.000    0.063    0.001 venv/local/lib/python2.7/site-packages/suds/bindings/binding.py:130(get_reply)
          100    0.000    0.000    0.061    0.001 venv/local/lib/python2.7/site-packages/spyne/server/_base.py:102(get_out_object)
          100    0.001    0.000    0.061    0.001 venv/local/lib/python2.7/site-packages/spyne/application.py:128(process_request)
          100    0.000    0.000    0.057    0.001 venv/local/lib/python2.7/site-packages/spyne/application.py:225(call_wrapper)

while without:

    no_gc.sort_stats('cumtime').print_stats(20)
    Thu Oct 29 14:31:07 2015    ./spyne2.12_no_gc
    
             208959 function calls (205348 primitive calls) in 0.291 seconds
    
       Ordered by: cumulative time
       List reduced from 566 to 20 due to restriction <20>
    
       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
          100    0.000    0.000    0.287    0.003 venv/local/lib/python2.7/site-packages/suds/client.py:530(__call__)
          100    0.001    0.000    0.285    0.003 venv/local/lib/python2.7/site-packages/suds/client.py:581(invoke)
          100    0.004    0.000    0.261    0.003 venv/local/lib/python2.7/site-packages/suds/client.py:610(send)
          100    0.001    0.000    0.182    0.002 venv/local/lib/python2.7/site-packages/bluetils/ws/suds_test.py:129(send)
          100    0.001    0.000    0.180    0.002 venv/local/lib/python2.7/site-packages/django/test/client.py:478(post)
          100    0.001    0.000    0.179    0.002 venv/local/lib/python2.7/site-packages/django/test/client.py:282(post)
          100    0.002    0.000    0.174    0.002 venv/local/lib/python2.7/site-packages/django/test/client.py:407(request)
          100    0.002    0.000    0.164    0.002 venv/local/lib/python2.7/site-packages/django/test/client.py:92(__call__)
          100    0.002    0.000    0.150    0.001 venv/local/lib/python2.7/site-packages/django/core/handlers/base.py:74(get_response)
          100    0.001    0.000    0.134    0.001 venv/local/lib/python2.7/site-packages/viewsgi.py:39(view)
          100    0.000    0.000    0.127    0.001 venv/local/lib/python2.7/site-packages/spyne/server/wsgi.py:229(__call__)
          100    0.002    0.000    0.125    0.001 venv/local/lib/python2.7/site-packages/spyne/server/wsgi.py:341(handle_rpc)
          100    0.002    0.000    0.061    0.001 venv/local/lib/python2.7/site-packages/suds/client.py:674(succeeded)
          100    0.003    0.000    0.057    0.001 venv/local/lib/python2.7/site-packages/suds/bindings/binding.py:130(get_reply)
          100    0.000    0.000    0.054    0.001 venv/local/lib/python2.7/site-packages/spyne/server/_base.py:102(get_out_object)
          100    0.001    0.000    0.054    0.001 venv/local/lib/python2.7/site-packages/spyne/application.py:128(process_request)
          100    0.000    0.000    0.050    0.001 venv/local/lib/python2.7/site-packages/spyne/application.py:225(call_wrapper)
          100    0.003    0.000    0.050    0.000 venv/local/lib/python2.7/site-packages/bluetils/ws/spyne.py:155(call_wrapper)
          100    0.001    0.000    0.028    0.000 venv/local/lib/python2.7/site-packages/suds/sax/parser.py:117(parse)
          100    0.001    0.000    0.024    0.000 venv/local/lib/python2.7/site-packages/spyne/server/_base.py:59(generate_contexts)


I'm not sure what you meant by `# this is important to have file descriptors returned in a timely manner` but calling `gc.collect()` for each WS call does not seem worth it...