### PR TITLE
Generate XmlAttribute in the correct location.

### DIFF
--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -272,7 +272,7 @@ def complex_add(document, cls, tags):
             attribute = etree.Element(XSD('attribute'))
             xml_attribute_add(v, k, attribute, document)
             if cls.Attributes._xml_tag_body_as is None:
-                complex_type.append(attribute)
+                sequence_parent.append(attribute)
             else:
                 xtba_ext.append(attribute)
             continue


### PR DESCRIPTION
Ensure the xmlAttribute element is generated in the correct location in the schema. In the case that the Model is *extended* then the attribute must be placed inside the `<xs:extension>` tag, rather than the `<xs:complexType>` tag.

In this case, appending it to sequence_parent is perfect because on an extended model the sequence_parent is the extension tag, and on a normal model the sequence_parent is the complexType tag.

Fixes https://github.com/arskom/spyne/issues/491