### PR TITLE
Proper serialization of inherited ComplexModels

### DIFF
--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -939,7 +939,7 @@ class ComplexModelBase(ModelBase):
                 cls_orig = cls.__orig__
             inst = cls_orig()
 
-            keys = cls._type_info.keys()
+            keys = cls.get_flat_type_info(cls).keys()
             for i in range(len(value)):
                 setattr(inst, keys[i], value[i])
 
@@ -949,7 +949,7 @@ class ComplexModelBase(ModelBase):
                 cls_orig = cls.__orig__
             inst = cls_orig()
 
-            for k in cls._type_info:
+            for k in cls.get_flat_type_info(cls):
                 setattr(inst, k, value.get(k, None))
 
         else:

--- a/spyne/test/model/test_complex.py
+++ b/spyne/test/model/test_complex.py
@@ -291,6 +291,16 @@ class TestIncompleteInput(unittest.TestCase):
         msg = element[0]
         r = XmlDocument().from_element(None, Y, msg)
 
+    def test_serialization_instance_on_subclass(self):
+        test_values = {
+            'x': [1, 2],
+            'y': 38
+        }
+        instance = Y.get_serialization_instance(test_values)
+
+        self.assertEqual(instance.x, [1, 2])
+        self.assertEqual(instance.y, 38)
+
 
 class SisMsg(ComplexModel):
     data_source = String(nillable=False, min_occurs=1, max_occurs=1, max_len=50)


### PR DESCRIPTION
When you have ComplexModels which subclass other models then `get_serialization_instance` is not settings values of fields from base model. 

Check my unit test for details (this tests fails on current version).