### PR TITLE
2 simple fixes: allow multiple calls from single instance and add PositiveInteger to __init__.py

### DIFF
--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -214,7 +214,7 @@ def _substitute_self_reference(params, kparams, kwargs, _no_self):
             kparams[k] = v
 
 
-def rpc(*params, **kparams):
+def rpc(*params, **kparams_original):
     """Method decorator to tag a method as a remote procedure call in a
     :class:`spyne.service.ServiceBase` subclass.
 
@@ -278,6 +278,7 @@ def rpc(*params, **kparams):
 
     def explain(f):
         def explain_method(**kwargs):
+            kparams = dict(kparams_original)
             function_name = kwargs['_default_function_name']
 
             # this block is passed straight to the descriptor

--- a/spyne/model/primitive/__init__.py
+++ b/spyne/model/primitive/__init__.py
@@ -80,6 +80,7 @@ from spyne.model.primitive.number import UnsignedInt
 from spyne.model.primitive.number import UnsignedInteger64
 from spyne.model.primitive.number import UnsignedLong
 from spyne.model.primitive.number import NonNegativeInteger # Xml Schema calls it so
+from spyne.model.primitive.number import PositiveInteger
 from spyne.model.primitive.number import UnsignedInteger
 
 from spyne.model.primitive.network import MacAddress


### PR DESCRIPTION
1.  pop from kparams broke ability to use given instance for several calls - this is especially usefull in unit tests - as severall tests could be run on single instance - making a copy of kparams before popping fixes it

2. PositiveInteger was missing from __init__.py