### PR TITLE
Backport of fix of silenced exceptions from 2.13

### DIFF
--- a/spyne/util/__init__.py
+++ b/spyne/util/__init__.py
@@ -119,11 +119,12 @@ def coroutine(func):
         try:
             next(ret)
 
-        except StopIteration as e:
+        except StopIteration:
             return None
 
         except Exception as e:
             logger.exception(e)
+            raise e
 
         return ret
 


### PR DESCRIPTION
Exceptions should not be silenced automatically - so I backported fix from 2.13 - please merge it.