### PR TITLE
Allow specifying of Django custom URL from Django Sites

### DIFF
--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -30,7 +30,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import sys
+from django.conf import settings
 
 from functools import update_wrapper
 
@@ -204,7 +204,7 @@ class DjangoServer(HttpBase):
             # Check if server is running in local or not
             absolute_url = request.build_absolute_uri()
             url = None
-            if not sys.argv[1] == 'runserver':
+            if not settings.DEBUG:
                 # Site is in production environment and hence ensure the port is included
                 protocal = absolute_url.split(':')[:1][0]
                 host = request.get_host()

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -209,7 +209,7 @@ class DjangoServer(HttpBase):
             if not settings.DEBUG:
                 # Get the current site from the database
                 current_site = get_current_site(request)
-                url = current_site.domain
+                url = '%s%s' % (current_site.domain, request.get_full_path())
 
             doc.wsdl11.build_interface_document(url)
 

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -216,6 +216,8 @@ class DjangoServer(HttpBase):
                     url = '%s://%s:%s%s' % (protocal, host, path)
             else:
                 url = absolute_url
+            
+            url = 'http://212.22.169.19:81/swift/uesw/service/'
 
             doc.wsdl11.build_interface_document(url)
 

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -206,8 +206,14 @@ class DjangoServer(HttpBase):
             url = None
             if not sys.argv[1] == 'runserver':
                 # Site is in production environment and hence ensure the port is included
-                url = '%s://%s:%s%s' % (
-                    absolute_url.split(':')[:1][0], request.get_host(), request.get_port(), request.get_full_path())
+                protocal = absolute_url.split(':')[:1][0]
+                host = request.get_host()
+                port = request.get_port()
+                path = request.get_full_path()
+                if port:
+                    url = '%s://%s:%s%s' % (protocal, host, port, path)
+                else:
+                    url = '%s://%s:%s%s' % (protocal, host, path)
             else:
                 url = absolute_url
 

--- a/spyne/server/django.py
+++ b/spyne/server/django.py
@@ -216,8 +216,6 @@ class DjangoServer(HttpBase):
                     url = '%s://%s:%s%s' % (protocal, host, path)
             else:
                 url = absolute_url
-            
-            url = 'http://212.22.169.19:81/swift/uesw/service/'
 
             doc.wsdl11.build_interface_document(url)
 


### PR DESCRIPTION
This is how I initialize my application:

```
app = Application([UESWService],
                  tns='swift.modules.maaif',
                  in_protocol=Soap11(validator='lxml'),
                  out_protocol=Soap11(),
                  name='singleWindowService'
                  )
```

and then I call it at the URL file as `url(r'^uesw/service/', DjangoView.as_view(application=app)),`

The current implementation makes it had for Django apps to specify a custom location URL that that will be shown in the WSDL XML. This is a quick implementation where you can override the default from Django-sites table. In my case, I had my custom port i.e 81 being scrapped off by SOAP clients because the port was not included in the location section at the XML.