### PR TITLE
Fix incorrect exception handling - seek on closed file

### DIFF
--- a/spyne/interface/xml_schema/_base.py
+++ b/spyne/interface/xml_schema/_base.py
@@ -220,8 +220,7 @@ class XmlSchema(InterfaceDocumentBase):
 
             with open(os.path.join(tmp_dir_name, "%s.xsd" % pref_tns), 'r') as f:
                 try:
-                    self.validation_schema = etree.XMLSchema(etree.parse(f))
-
+                    parsed_etree = etree.parse(f)
                 except Exception:
                     f.seek(0)
                     logger.error("This could be a Spyne error. Unless you're "
@@ -229,6 +228,7 @@ class XmlSchema(InterfaceDocumentBase):
                                  "Spyne, please open a new issue with a "
                                  "minimal test case that reproduces it.")
                     raise
+                self.validation_schema = etree.XMLSchema(parsed_etree)
 
             shutil.rmtree(tmp_dir_name)
             logger.debug("Schema built. Removed %r" % tmp_dir_name)


### PR DESCRIPTION
When exception appeared in etree.XMLSchema after etree.parse(f) is finished - f is already closed and f.seek(0) generates another exception that hides the original one (Python 2.x)