### PR TITLE
Fixed inclusive boundaries for Date and Time fields

### DIFF
--- a/spyne/model/primitive/datetime.py
+++ b/spyne/model/primitive/datetime.py
@@ -46,13 +46,13 @@ class Time(SimpleModel):
         """Customizable attributes of the :class:`spyne.model.primitive.Time`
         type."""
 
-        gt = datetime.time(0, 0, 0, 0)  # minExclusive
+        gt = None  # minExclusive
         """The time should be greater than this time."""
 
         ge = datetime.time(0, 0, 0, 0)  # minInclusive
         """The time should be greater than or equal to this time."""
 
-        lt = datetime.time(23, 59, 59, 999999)  # maxExclusive
+        lt = None  # maxExclusive
         """The time should be lower than this time."""
 
         le = datetime.time(23, 59, 59, 999999)  # maxInclusive
@@ -76,9 +76,9 @@ class Time(SimpleModel):
     def validate_native(cls, value):
         return SimpleModel.validate_native(cls, value) and (
             value is None or (
-                    value >  cls.Attributes.gt
+                (cls.Attributes.gt is None or value >  cls.Attributes.gt)
                 and value >= cls.Attributes.ge
-                and value <  cls.Attributes.lt
+                and (cls.Attributes.lt is None or value <  cls.Attributes.lt)
                 and value <= cls.Attributes.le
             ))
 
@@ -107,7 +107,7 @@ class DateTime(SimpleModel):
         """Customizable attributes of the :class:`spyne.model.primitive.DateTime`
         type."""
 
-        gt = _min_dt  # minExclusive
+        gt = None  # minExclusive
         """The datetime should be greater than this datetime. It must always
         have a timezone."""
 
@@ -115,7 +115,7 @@ class DateTime(SimpleModel):
         """The datetime should be greater than or equal to this datetime. It
         must always have a timezone."""
 
-        lt = _max_dt  # maxExclusive
+        lt = None  # maxExclusive
         """The datetime should be lower than this datetime. It must always have
         a timezone."""
 
@@ -194,10 +194,10 @@ class DateTime(SimpleModel):
         return SimpleModel.validate_native(cls, value) and (
             value is None or (
                 # min_dt is also a valid value if gt is intact.
-                    (cls.Attributes.gt is _min_dt or value > cls.Attributes.gt)
+                    (cls.Attributes.gt is None or value > cls.Attributes.gt)
                 and value >= cls.Attributes.ge
                 # max_dt is also a valid value if lt is intact.
-                and (cls.Attributes.lt is _max_dt or value < cls.Attributes.lt)
+                and (cls.Attributes.lt is None or value < cls.Attributes.lt)
                 and value <= cls.Attributes.le
             ))
 
@@ -217,16 +217,16 @@ class Date(DateTime):
         """Customizable attributes of the :class:`spyne.model.primitive.Date`
         type."""
 
-        gt = datetime.date(1, 1, 1) # minExclusive
+        gt = None  # minExclusive
         """The date should be greater than this date."""
 
-        ge = datetime.date(1, 1, 1) # minInclusive
+        ge = datetime.date(1, 1, 1)  # minInclusive
         """The date should be greater than or equal to this date."""
 
-        lt = datetime.date(datetime.MAXYEAR, 12, 31) # maxExclusive
+        lt = None  # maxExclusive
         """The date should be lower than this date."""
 
-        le = datetime.date(datetime.MAXYEAR, 12, 31) # maxInclusive
+        le = datetime.date(datetime.MAXYEAR, 12, 31)  # maxInclusive
         """The date should be lower than or equal to this date."""
 
         format = '%Y-%m-%d'

--- a/spyne/test/model/test_primitive.py
+++ b/spyne/test/model/test_primitive.py
@@ -29,6 +29,7 @@ import pytz
 
 from datetime import timedelta
 
+import spyne
 from lxml import etree
 
 from spyne.util import six, total_seconds
@@ -283,6 +284,58 @@ class TestPrimitive(unittest.TestCase):
         self.assertEquals(dt.year, 2007)
         self.assertEquals(dt.month, 5)
         self.assertEquals(dt.day, 15)
+
+    def test_date_exclusive_boundaries(self):
+        test_model = Date.customize(gt=datetime.date(2016, 1, 1), lt=datetime.date(2016, 2, 1))
+        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+
+    def test_date_inclusive_boundaries(self):
+        test_model = Date.customize(ge=datetime.date(2016, 1, 1), le=datetime.date(2016, 2, 1))
+        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+
+    def test_datetime_exclusive_boundaries(self):
+        test_model = DateTime.customize(
+            gt=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
+            lt=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+        self.assertFalse(test_model.validate_native(test_model,
+                                                    datetime.datetime(2016, 1, 1, 12, 00)))
+        self.assertFalse(test_model.validate_native(test_model,
+                                                    datetime.datetime(2016, 2, 1, 12, 00)))
+
+    def test_datetime_inclusive_boundaries(self):
+        test_model = DateTime.customize(
+            ge=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
+            le=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+        self.assertTrue(test_model.validate_native(test_model,
+                                                   datetime.datetime(2016, 1, 1, 12, 00)))
+        self.assertTrue(test_model.validate_native(test_model,
+                                                   datetime.datetime(2016, 2, 1, 12, 00)))
+
+    def test_time_exclusive_boundaries(self):
+        test_model = Time.customize(gt=datetime.time(12, 00),
+                                    lt=datetime.time(13, 00))
+        self.assertFalse(test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertFalse(test_model.validate_native(test_model, datetime.time(13, 00)))
+
+    def test_time_inclusive_boundaries(self):
+        test_model = Time.customize(ge=datetime.time(12, 00),
+                                    le=datetime.time(13, 00))
+        self.assertTrue(test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertTrue(test_model.validate_native(test_model, datetime.time(13, 00)))
+
+    def test_datetime_extreme_boundary(self):
+        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.min))
+        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.max))
+
+    def test_time_extreme_boundary(self):
+        self.assertTrue(Time.validate_native(Time, datetime.time(0,0,0,0)))
+        self.assertTrue(Time.validate_native(Time, datetime.time(23, 59, 59, 999999)))
+
+    def test_date_extreme_boundary(self):
+        self.assertTrue(Date.validate_native(Date, datetime.date.min))
+        self.assertTrue(Date.validate_native(Date, datetime.date.max))
 
     def test_integer(self):
         i = 12


### PR DESCRIPTION
In previous version we could not use min or max for Date and Time fields as inclusive border because they were catch by exclusive.

From attached unittests `test_time_extreme_boundary` and `test_date_extreme_boundary` was failing, while test_datetime_extreme_boundary was passing.
