### PR TITLE
Renamed _soap_port_type to _port_type

### DIFF
--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -290,7 +290,7 @@ def rpc(*params, **kparams):
             _mtom = kparams.pop('_mtom', False)
             _in_header = kparams.pop('_in_header', None)
             _out_header = kparams.pop('_out_header', None)
-            _port_type = kparams.pop('_soap_port_type', None)
+            _port_type = kparams.pop('_port_type', None)
             _no_ctx = kparams.pop('_no_ctx', False)
             _no_self = kparams.pop('_no_self', True)
             _udp = kparams.pop('_udp', None)

--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -470,7 +470,7 @@ class Wsdl11(XmlSchema):
 
                 # create binding nodes
                 binding = SubElement(root, WSDL11("binding"))
-                binding.set('name', port_type_name)
+                binding.set('name', self._get_binding_name(port_type_name))
                 binding.set('type', '%s:%s'% (pref_tns, port_type_name))
 
                 transport = SubElement(binding, WSDL11_SOAP("binding"))

--- a/spyne/test/interface/wsdl/port_service_services.py
+++ b/spyne/test/interface/wsdl/port_service_services.py
@@ -53,7 +53,7 @@ def TS3():
         def echo(self, string):
             return string
 
-        @rpc(String, _soap_port_type='bobhope', _returns=String)
+        @rpc(String, _port_type='bobhope', _returns=String)
         def echo_bob_hope(self,  string):
             return 'Bob Hope'
 
@@ -78,7 +78,7 @@ def TBadRPCPortService():
         __service_name__ = 'MissingRPCPortService'
         __port_types__ = ['existing']
 
-        @rpc(String, _soap_port_type='existingss', _returns=String)
+        @rpc(String, _port_type='existingss', _returns=String)
         def raise_exception(self, string):
             return string
 
@@ -91,7 +91,7 @@ def TMissingServicePortService():
         __service_name__ = 'MissingRPCPortService'
         __port_types__ = ['existing']
 
-        @rpc(String, _soap_port_type='existingss', _returns=String)
+        @rpc(String, _port_type='existingss', _returns=String)
         def raise_exception(self, string):
             return string
 
@@ -104,7 +104,7 @@ def TSinglePortService():
         __namespace__ = 'SinglePortNS'
         __port_types__ = ['FirstPortType']
 
-        @rpc(String, _soap_port_type='FirstPortType', _returns=String)
+        @rpc(String, _port_type='FirstPortType', _returns=String)
         def echo_default_port_service(self, string):
             return string
 
@@ -116,11 +116,11 @@ def TDoublePortService():
         __namespace__ = 'DoublePort'
         __port_types__ = ['FirstPort', 'SecondPort']
 
-        @rpc(String, _soap_port_type='FirstPort', _returns=String)
+        @rpc(String, _port_type='FirstPort', _returns=String)
         def echo_first_port(self, string):
             return string
 
-        @rpc(String, _soap_port_type='SecondPort', _returns=String)
+        @rpc(String, _port_type='SecondPort', _returns=String)
         def echo_second_port(self, string):
             return string
 


### PR DESCRIPTION
The documentation in decorator.py states, that _port_type
should be used to set the port type - nevertheless instead of
_port_type _soap_port_type is picked up.

The patch adapts the source code to the documentation and uses
_port_type.