### PR TITLE
This replaces any use of the deprecated `spyne.const.xml_ns` with `spyne.const.xml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  # disable pypy -- travis' pypy deployment seems broken
-  # - "pypy"
-before_install:
-  #- sudo apt-get update
-  #- sudo apt-get install -qq libzmq-dev
+matrix:
+  include:
+  - python: "2.7"
+    env: TEST_SUITE=test
+  - python: "3.4"
+    env: TEST_SUITE=test_python3
+  - python: "3.5"
+    env: TEST_SUITE=test_python3
 install:
-  - pip install tox
-script:
   - pip install -r requirements/test_requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then  python setup.py test; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then  python setup.py test_python3; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then  python setup.py test_python3; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pypi setup.py test; fi
+script:
+  - python setup.py $TEST_SUITE
+  

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ spyne-2.13.0
   ``spyne.BODY_STYLE_EMPTY`` before. This hould not break anything unless you
   are doing some REAL fancy stuff in the method decorators or service events.
 * Auxproc is DEPRECATED. Just get rid of it.
+* `spyne.const.xml_ns` is deprecated. Replaced uses by `spyne.const.xml`.
 * `spyne.protocol.dictdoc.simple`, `spyne.server.twisted.http` and
   `spyne.server.django` are not experimental anymore.
 * No major changes otherwise but we paid a lot of technical debt. e.g. We

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=2.9
 pytest-twisted
 pytest-cov
 coverage

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 #
 # Sets up a Python testing environment from scratch. Mainly written for Jenkins.
+# Works for CPython. Not working for Jython, IronPython and PyPy.
 #
 # Requirements:
 #   A working build environment inside the container with OpenSSL, bzip2,

--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,6 @@ class RunTests(ExtendedTestCommand):
             ret = call_pytest_subprocess('interop/test_zeep.py',
                                                     capture=self.capture) or ret
 
-        ret = call_tox_subprocess('py%s-dj17' % PYVER) or ret
         ret = call_tox_subprocess('py%s-dj18' % PYVER) or ret
         ret = call_tox_subprocess('py%s-dj19' % PYVER) or ret
         ret = call_tox_subprocess('py%s-dj110' % PYVER) or ret

--- a/spyne/const/xml.py
+++ b/spyne/const/xml.py
@@ -35,6 +35,7 @@ NS_SOAP12_ENV = 'http://www.w3.org/2003/05/soap-envelope'
 
 NS_WSDL11 = 'http://schemas.xmlsoap.org/wsdl/'
 NS_WSDL11_SOAP = 'http://schemas.xmlsoap.org/wsdl/soap/'
+NS_WSDL12_SOAP = 'http://schemas.xmlsoap.org/wsdl/soap12/'
 
 NSMAP = {
     'xml': NS_XML,
@@ -42,6 +43,7 @@ NSMAP = {
     'xsi': NS_XSI,
     'plink': NS_PLINK,
     'wsdlsoap11': NS_WSDL11_SOAP,
+    'wsdlsoap12': NS_WSDL12_SOAP,
     'wsdl': NS_WSDL11,
     'soap11enc': NS_SOAP11_ENC,
     'soap11env': NS_SOAP11_ENV,
@@ -82,6 +84,7 @@ SOAP12_ENC = Tnswrap(NS_SOAP12_ENC)
 SOAP12_ENV = Tnswrap(NS_SOAP12_ENV)
 WSDL11 = Tnswrap(NS_WSDL11)
 WSDL11_SOAP = Tnswrap(NS_WSDL11_SOAP)
+WSDL12_SOAP = Tnswrap(NS_WSDL12_SOAP)
 
 
 # names starting with underscore need () around to be used as proper regexps

--- a/spyne/const/xml_ns.py
+++ b/spyne/const/xml_ns.py
@@ -19,7 +19,6 @@
 
 # This module is DEPRECATED. Use ``spyne.const.xml``.
 
-# FIXME: These are constants, so should have been all UPPERCASE.
 xml = 'http://www.w3.org/XML/1998/namespace'
 xsd = 'http://www.w3.org/2001/XMLSchema'
 xsi = 'http://www.w3.org/2001/XMLSchema-instance'

--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -26,7 +26,7 @@ to have a more elegant way of passing frequently-used parameter values. The @rpc
 decorator is a simple example of this.
 """
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from copy import copy
 from inspect import isclass
@@ -84,7 +84,7 @@ def _produce_input_message(f, params, in_message_name,
         k = in_variable_names.get(k, k)
         in_params[k] = v
 
-    ns = spyne.const.xml_ns.DEFAULT_NS
+    ns = spyne.const.xml.DEFAULT_NS
     if in_message_name.startswith("{"):
         ns, _, in_message_name = in_message_name[1:].partition("}")
 
@@ -179,7 +179,7 @@ def _produce_output_message(func_name, body_style_str, kparams):
 
             out_params[_out_variable_name] = _returns
 
-    ns = spyne.const.xml_ns.DEFAULT_NS
+    ns = spyne.const.xml.DEFAULT_NS
     if _out_message_name.startswith("{"):
         ns = _out_message_name[1:].partition("}")[0]
 

--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -42,7 +42,7 @@ from spyne import BODY_STYLE_OUT_BARE
 from spyne import BODY_STYLE_EMPTY_OUT_BARE
 
 from spyne.model import ModelBase, ComplexModel
-from spyne.model.complex import TypeInfo
+from spyne.model.complex import TypeInfo, recust_selfref
 
 from spyne.const import add_request_suffix
 
@@ -205,8 +205,7 @@ def _substitute_self_reference(params, kparams, kwargs, _no_self):
         if isclass(v) and issubclass(v, SelfReference):
             if _no_self:
                 raise ValueError("SelfReference can't be used in @rpc")
-            else:
-                params[i] = kwargs['_self_ref_replacement']
+            params[i] = recust_selfref(v, kwargs['_self_ref_replacement'])
         else:
             params[i] = v
 
@@ -214,8 +213,7 @@ def _substitute_self_reference(params, kparams, kwargs, _no_self):
         if isclass(v) and issubclass(v, SelfReference):
             if _no_self:
                 raise ValueError("SelfReference can't be used in @rpc")
-            else:
-                kparams[k] = kwargs['_self_ref_replacement']
+            kparams[k] = recust_selfref(v, kwargs['_self_ref_replacement'])
         else:
             kparams[k] = v
 

--- a/spyne/descriptor.py
+++ b/spyne/descriptor.py
@@ -20,7 +20,7 @@
 import logging
 logger = logging.getLogger('spyne')
 
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 
 from spyne.util import six
 

--- a/spyne/descriptor.py
+++ b/spyne/descriptor.py
@@ -236,7 +236,7 @@ class MethodDescriptor(object):
 
         # this is a member method decorated by @mrpc
         else:
-            mn = cls.get_namespace()
+            mn = cls.get_namespace() or '__nons__'
             on = cls.get_type_name()
 
             dn = self.name

--- a/spyne/interface/_base.py
+++ b/spyne/interface/_base.py
@@ -28,7 +28,7 @@ from spyne import EventManager, MethodDescriptor
 from spyne.util import six
 from spyne.model import ModelBase, Array, Iterable, ComplexModelBase
 from spyne.model.complex import XmlModifier
-from spyne.const import xml_ns as namespace
+from spyne.const import xml as namespace
 
 
 class Interface(object):
@@ -79,8 +79,8 @@ class Interface(object):
         self.imports = {self.get_tns(): set()}
         self.service_method_map = {}
         self.method_id_map = {}
-        self.nsmap = dict(namespace.const_nsmap)
-        self.prefmap = dict(namespace.const_prefmap)
+        self.nsmap = dict(namespace.NSMAP)
+        self.prefmap = dict(namespace.PREFMAP)
         self.member_methods = deque()
 
         self.nsmap['tns'] = self.get_tns()
@@ -485,7 +485,7 @@ class Interface(object):
         if ns is None:
             raise ValueError(ns)
 
-        return self.import_base_namespaces or not (ns in namespace.const_prefmap)
+        return self.import_base_namespaces or not (ns in namespace.PREFMAP)
 
 
 class AllYourInterfaceDocuments(object):

--- a/spyne/interface/wsdl/defn.py
+++ b/spyne/interface/wsdl/defn.py
@@ -1,7 +1,7 @@
 
 from spyne.util.six import add_metaclass
 
-from spyne.const import xml_ns
+from spyne.const import xml
 
 from spyne.model.primitive import Unicode
 from spyne.model.complex import XmlAttribute
@@ -12,12 +12,12 @@ from spyne.interface.xml_schema.defn import XmlSchema10
 
 @add_metaclass(ComplexModelMeta)
 class Wsdl11Base(ComplexModelBase):
-    __namespace__ = xml_ns.wsdl
+    __namespace__ = xml.NS_WSDL11
 
 
 @add_metaclass(ComplexModelMeta)
 class Soap11Base(ComplexModelBase):
-    __namespace__ = xml_ns.soap
+    __namespace__ = xml.NS_WSDL11_SOAP
 
 
 class Types(Wsdl11Base):
@@ -47,9 +47,9 @@ class SoapHeaderDefinition(Wsdl11Base):
 class OperationMode(Wsdl11Base):
     name = XmlAttribute(Unicode)
     message = XmlAttribute(Unicode)
-    soap_body = SoapBodyDefinition.customize(sub_ns=xml_ns.soap,
+    soap_body = SoapBodyDefinition.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                               sub_name="body")
-    soap_header = SoapHeaderDefinition.customize(sub_ns=xml_ns.soap,
+    soap_header = SoapHeaderDefinition.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                               sub_name="header")
 
 
@@ -61,7 +61,7 @@ class SoapOperation(Wsdl11Base):
 class Operation(Wsdl11Base):
     input = OperationMode
     output = OperationMode
-    soap_operation = SoapOperation.customize(sub_ns=xml_ns.soap,
+    soap_operation = SoapOperation.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                              sub_name="operation")
     parameterOrder = XmlAttribute(Unicode)
 
@@ -79,7 +79,7 @@ class Binding(Wsdl11Base):
     name = XmlAttribute(Unicode)
     type = XmlAttribute(Unicode)
     location = XmlAttribute(Unicode)
-    soap_binding = SoapBinding.customize(sub_ns=xml_ns.soap,
+    soap_binding = SoapBinding.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                            sub_name="binding")
 
 
@@ -90,7 +90,7 @@ class PortAddress(Soap11Base):
 class ServicePort(Wsdl11Base):
     name = XmlAttribute(Unicode)
     binding = XmlAttribute(Unicode)
-    address = PortAddress.customize(sub_ns=xml_ns.soap)
+    address = PortAddress.customize(sub_ns=xml.NS_WSDL11_SOAP)
 
 
 class Service(Wsdl11Base):

--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 import re
 REGEX_WSDL = re.compile('[.?]wsdl$')
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from lxml import etree
 from lxml.builder import E

--- a/spyne/interface/xml_schema/_base.py
+++ b/spyne/interface/xml_schema/_base.py
@@ -24,7 +24,7 @@ import os
 import shutil
 import tempfile
 
-import spyne.const.xml_ns
+import spyne.const.xml as ns
 
 from lxml import etree
 from itertools import chain
@@ -68,11 +68,11 @@ _get_restriction_tag_handlers = cdict({
     Date: Tget_range_restriction_tag(Date),
 })
 
-_ns_xsd = spyne.const.xml_ns.xsd
-_ns_wsa = spyne.const.xml_ns.wsa
-_ns_wsdl = spyne.const.xml_ns.wsdl
-_ns_soap = spyne.const.xml_ns.soap
-_pref_wsa = spyne.const.xml_ns.const_prefmap[_ns_wsa]
+_ns_xsd = ns.NS_XSD
+_ns_wsa = ns.NS_WSA
+_ns_wsdl = ns.NS_WSDL11
+_ns_soap = ns.NS_WSDL11_SOAP
+_pref_wsa = ns.PREFMAP[_ns_wsa]
 
 
 class SchemaInfo(object):
@@ -137,7 +137,7 @@ class XmlSchema(InterfaceDocumentBase):
 
             # append import tags
             for namespace in self.interface.imports[self.interface.nsmap[pref]]:
-                import_ = etree.SubElement(schema, "{%s}import" % _ns_xsd)
+                import_ = etree.SubElement(schema, ns.XSD('import'))
 
                 import_.set("namespace", namespace)
                 import_pref = self.interface.get_namespace_prefix(namespace)
@@ -145,7 +145,7 @@ class XmlSchema(InterfaceDocumentBase):
                                         self.namespaces.get(import_pref, False):
                     import_.set('schemaLocation', "%s.xsd" % import_pref)
 
-                sl = spyne.const.xml_ns.schema_location.get(namespace, None)
+                sl = ns.schema_location.get(namespace, None)
                 if not (sl is None):
                     import_.set('schemaLocation', sl)
 
@@ -179,7 +179,7 @@ class XmlSchema(InterfaceDocumentBase):
                 name = method.in_message.get_type_name()
 
             if not name in elements:
-                element = etree.Element('{%s}element' % _ns_xsd)
+                element = etree.Element(ns.XSD('element'))
                 element.set('name', name)
                 element.set('type', method.in_message.get_type_name_ns(
                                                                 self.interface))
@@ -191,7 +191,7 @@ class XmlSchema(InterfaceDocumentBase):
                 if name is None:
                     name = method.out_message.get_type_name()
                 if not name in elements:
-                    element = etree.Element('{%s}element' % _ns_xsd)
+                    element = etree.Element(ns.XSD('element'))
                     element.set('name', name)
                     element.set('type', method.out_message \
                                               .get_type_name_ns(self.interface))
@@ -242,7 +242,7 @@ class XmlSchema(InterfaceDocumentBase):
         """Return schema node for the given namespace prefix."""
 
         if not (pref in self.schema_dict):
-            schema = etree.Element("{%s}schema" % _ns_xsd,
+            schema = etree.Element(ns.XSD('schema'),
                                                      nsmap=self.interface.nsmap)
 
             schema.set("targetNamespace", self.interface.nsmap[pref])

--- a/spyne/interface/xml_schema/defn.py
+++ b/spyne/interface/xml_schema/defn.py
@@ -19,7 +19,7 @@
 
 from spyne.util.six import add_metaclass
 
-from spyne.const import xml_ns
+from spyne.const import xml
 from spyne.model.primitive import Boolean, AnyHtml
 from spyne.model.primitive import Unicode
 from spyne.model.primitive import UnsignedInteger
@@ -30,7 +30,7 @@ from spyne.model.complex import ComplexModelMeta
 
 @add_metaclass(ComplexModelMeta)
 class SchemaBase(ComplexModelBase):
-    __namespace__ = xml_ns.xsd
+    __namespace__ = xml.NS_XSD
 
 
 class Import(SchemaBase):

--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -31,15 +31,13 @@ from lxml import etree
 
 from spyne.model import ModelBase, XmlAttribute, AnyXml, Unicode, XmlData, \
     Decimal, Integer
-from spyne.const.xml_ns import xsd as _ns_xsd
+from spyne.const.xml import NS_XSD, XSD
 from spyne.util import memoize
 from spyne.util.cdict import cdict
 from spyne.util.etreeconv import dict_to_etree
 from spyne.util.six import string_types
 from spyne.protocol.xml import XmlDocument
 _prot = XmlDocument()
-
-XSD = lambda s: '{%s}%s' % (_ns_xsd, s)
 
 # In Xml Schema, some customizations do not need a class to be extended -- they
 # are specified in-line in the parent class definition, like nullable or
@@ -292,7 +290,7 @@ def enum_add(document, cls, tags):
 
     restriction = etree.SubElement(simple_type, XSD('restriction'))
     restriction.set('base', '%s:string' %
-                               document.interface.get_namespace_prefix(_ns_xsd))
+                               document.interface.get_namespace_prefix(NS_XSD))
 
     for v in cls.__values__:
         enumeration = etree.SubElement(restriction, XSD('enumeration'))

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -30,7 +30,7 @@ import re
 import decimal
 import threading
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from collections import OrderedDict
 
@@ -39,7 +39,7 @@ from spyne.util import Break, six
 from spyne.util.cdict import cdict
 from spyne.util.odict import odict
 
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 
 
 def _decode_pa_dict(d):
@@ -270,7 +270,7 @@ class ModelBase(object):
         will imply an iterable of objects as native python type. Can be set to
         ``decimal.Decimal("inf")`` for arbitrary number of arguments."""
 
-        schema_tag = '{%s}element' % spyne.const.xml_ns.xsd
+        schema_tag = spyne.const.xml.XSD('element')
         """The tag used to add a primitives as child to a complex type in the
         xml schema."""
 
@@ -482,10 +482,10 @@ class ModelBase(object):
             return False
         tags.add(cls)
 
-        if cls.__namespace__ is spyne.const.xml_ns.DEFAULT_NS:
+        if cls.__namespace__ is spyne.const.xml.DEFAULT_NS:
             cls.__namespace__ = default_ns
 
-        if (cls.__namespace__ in spyne.const.xml_ns.const_prefmap and
+        if (cls.__namespace__ in spyne.const.xml.PREFMAP and
                                                        not cls.is_default(cls)):
             cls.__namespace__ = default_ns
 

--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -39,7 +39,7 @@ from itertools import chain
 from spyne import BODY_STYLE_BARE, BODY_STYLE_WRAPPED, EventManager
 
 from spyne import const
-from spyne.const import xml_ns
+from spyne.const.xml import PREFMAP
 
 from spyne.model import Point, Unicode, PushBase, ModelBase
 from spyne.model import json, xml, msgpack, table
@@ -123,7 +123,7 @@ class XmlModifier(ModelBase):
         if cls.__namespace__ is None:
             cls.__namespace__ = cls.type.get_namespace()
 
-        if cls.__namespace__ in xml_ns.const_prefmap:
+        if cls.__namespace__ in PREFMAP:
             cls.__namespace__ = default_ns
 
     @classmethod
@@ -1442,7 +1442,7 @@ class Array(ComplexModelBase):
         if cls.__namespace__ is None:
             cls.__namespace__ = serializer.get_namespace()
 
-        if cls.__namespace__ in xml_ns.const_prefmap:
+        if cls.__namespace__ in PREFMAP:
             cls.__namespace__ = default_ns
 
         return ComplexModel.resolve_namespace(cls, default_ns, tags)

--- a/spyne/model/primitive/datetime.py
+++ b/spyne/model/primitive/datetime.py
@@ -46,13 +46,13 @@ class Time(SimpleModel):
         """Customizable attributes of the :class:`spyne.model.primitive.Time`
         type."""
 
-        gt = datetime.time(0, 0, 0, 0)  # minExclusive
+        gt = None  # minExclusive
         """The time should be greater than this time."""
 
         ge = datetime.time(0, 0, 0, 0)  # minInclusive
         """The time should be greater than or equal to this time."""
 
-        lt = datetime.time(23, 59, 59, 999999)  # maxExclusive
+        lt = None  # maxExclusive
         """The time should be lower than this time."""
 
         le = datetime.time(23, 59, 59, 999999)  # maxInclusive
@@ -76,9 +76,9 @@ class Time(SimpleModel):
     def validate_native(cls, value):
         return SimpleModel.validate_native(cls, value) and (
             value is None or (
-                    value >  cls.Attributes.gt
+                (cls.Attributes.gt is None or value >  cls.Attributes.gt)
                 and value >= cls.Attributes.ge
-                and value <  cls.Attributes.lt
+                and (cls.Attributes.lt is None or value <  cls.Attributes.lt)
                 and value <= cls.Attributes.le
             ))
 
@@ -107,7 +107,7 @@ class DateTime(SimpleModel):
         """Customizable attributes of the :class:`spyne.model.primitive.DateTime`
         type."""
 
-        gt = _min_dt  # minExclusive
+        gt = None  # minExclusive
         """The datetime should be greater than this datetime. It must always
         have a timezone."""
 
@@ -115,7 +115,7 @@ class DateTime(SimpleModel):
         """The datetime should be greater than or equal to this datetime. It
         must always have a timezone."""
 
-        lt = _max_dt  # maxExclusive
+        lt = None  # maxExclusive
         """The datetime should be lower than this datetime. It must always have
         a timezone."""
 
@@ -194,10 +194,10 @@ class DateTime(SimpleModel):
         return SimpleModel.validate_native(cls, value) and (
             value is None or (
                 # min_dt is also a valid value if gt is intact.
-                    (cls.Attributes.gt is _min_dt or value > cls.Attributes.gt)
+                    (cls.Attributes.gt is None or value > cls.Attributes.gt)
                 and value >= cls.Attributes.ge
                 # max_dt is also a valid value if lt is intact.
-                and (cls.Attributes.lt is _max_dt or value < cls.Attributes.lt)
+                and (cls.Attributes.lt is None or value < cls.Attributes.lt)
                 and value <= cls.Attributes.le
             ))
 
@@ -217,16 +217,16 @@ class Date(DateTime):
         """Customizable attributes of the :class:`spyne.model.primitive.Date`
         type."""
 
-        gt = datetime.date(1, 1, 1) # minExclusive
+        gt = None  # minExclusive
         """The date should be greater than this date."""
 
-        ge = datetime.date(1, 1, 1) # minInclusive
+        ge = datetime.date(1, 1, 1)  # minInclusive
         """The date should be greater than or equal to this date."""
 
-        lt = datetime.date(datetime.MAXYEAR, 12, 31) # maxExclusive
+        lt = None  # maxExclusive
         """The date should be lower than this date."""
 
-        le = datetime.date(datetime.MAXYEAR, 12, 31) # maxInclusive
+        le = datetime.date(datetime.MAXYEAR, 12, 31)  # maxInclusive
         """The date should be lower than or equal to this date."""
 
         format = '%Y-%m-%d'

--- a/spyne/protocol/cloth/to_cloth.py
+++ b/spyne/protocol/cloth/to_cloth.py
@@ -594,6 +594,7 @@ class ToClothMixin(OutProtocolBase, ClothParserMixin):
 
                     # disabled for performance reasons
                     # identifier = "%s.%s" % (prot_name, handler.__name__)
+                    # from spyne.util.web import log_repr
                     # logger_s.debug("Writing %s using %s for %s. Inst: %r",
                     #                  name, identifier, cls.get_type_name(),
                     #                  log_repr(inst, cls, from_array=from_arr))

--- a/spyne/protocol/cloth/to_cloth.py
+++ b/spyne/protocol/cloth/to_cloth.py
@@ -58,12 +58,6 @@ def _prevsibls_since(elt, since):
         yield prevsibl
 
 
-def _gen_tagname(ns, name):
-    if ns is not None:
-        name = "{%s}%s" % (ns, name)
-    return name
-
-
 def _set_identifier_prefix(obj, prefix, mrpc_id='mrpc', id_attr='id',
                             data_tag='data', data_attr='data', attr_attr='attr',
                                         root_attr='root', tagbag_attr='tagbag'):
@@ -665,29 +659,7 @@ class ToClothMixin(OutProtocolBase, ClothParserMixin):
         fti_check = dict(fti.items())
         elt_check = set()
 
-        # Check for xmlattribute before entering the cloth.
-        attrs = {}
-        for field_name, field_type in fti.attrs.items():
-            ns = field_type._ns
-            if ns is None:
-                ns = field_type.Attributes.sub_ns
-
-            sub_name = field_type.Attributes.sub_name
-            if sub_name is None:
-                sub_name = field_name
-
-            val = getattr(inst, field_name, None)
-            sub_name = _gen_tagname(ns, sub_name)
-
-            if val is not None:
-                if issubclass(field_type.type, (ByteArray, File)):
-                    valstr = self.to_unicode(field_type.type, val,
-                                                           self.binary_encoding)
-                else:
-                    valstr = self.to_unicode(field_type.type, val)
-
-                attrs[sub_name] = valstr
-
+        attrs = self._gen_attr_dict(inst, fti)
         self._enter_cloth(ctx, cloth, parent, attrs=attrs)
 
         for elt in self._get_elts(cloth, self.MRPC_ID):

--- a/spyne/protocol/cloth/to_parent.py
+++ b/spyne/protocol/cloth/to_parent.py
@@ -168,10 +168,11 @@ class ToParentMixin(OutProtocolBase):
                     logger.debug("%s %r pushed %r %r", R("$"), self, cls, inst)
 
                     # disabled for performance reasons
-                    #identifier = "%s.%s" % (prot_name, handler.__name__)
-                    #log_str = log_repr(inst, cls,
+                    # from spyne.util.web import log_repr
+                    # identifier = "%s.%s" % (prot_name, handler.__name__)
+                    # log_str = log_repr(inst, cls,
                     #                   from_array=kwargs.get('from_arr', None))
-                    #logger.debug("Writing %s using %s for %s. Inst: %r", name,
+                    # logger.debug("Writing %s using %s for %s. Inst: %r", name,
                     #                  identifier, cls.get_type_name(), log_str)
 
                     # finally, serialize the value. retval is the coroutine

--- a/spyne/protocol/cloth/to_parent.py
+++ b/spyne/protocol/cloth/to_parent.py
@@ -28,7 +28,7 @@ from collections import Iterable
 from lxml import etree, html
 from lxml.builder import E
 
-from spyne.const.xml_ns import xsi as NS_XSI, soap11_env as NS_SOAP_ENV
+from spyne.const.xml import NS_XSI, NS_SOAP11_ENV, SOAP11_ENV
 from spyne.model import PushBase, ComplexModelBase, AnyXml, Fault, AnyDict, \
     AnyHtml, ModelBase, ByteArray, XmlData, Any, AnyUri, ImageUri, XmlAttribute
 
@@ -475,8 +475,8 @@ class ToParentMixin(OutProtocolBase):
                         pass
 
     def fault_to_parent(self, ctx, cls, inst, parent, name):
-        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP_ENV]
-        tag_name = "{%s}Fault" % NS_SOAP_ENV
+        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP11_ENV]
+        tag_name = SOAP11_ENV("Fault")
 
         with parent.element(tag_name):
             parent.write(
@@ -494,8 +494,8 @@ class ToParentMixin(OutProtocolBase):
             # PushBase instance here.
 
     def schema_validation_error_to_parent(self, ctx, cls, inst, parent, **_):
-        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP_ENV]
-        tag_name = "{%s}Fault" % NS_SOAP_ENV
+        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP11_ENV]
+        tag_name = SOAP11_ENV("Fault")
 
         with parent.element(tag_name):
             parent.write(

--- a/spyne/protocol/cloth/to_parent.py
+++ b/spyne/protocol/cloth/to_parent.py
@@ -30,7 +30,8 @@ from lxml.builder import E
 
 from spyne.const.xml_ns import xsi as NS_XSI, soap11_env as NS_SOAP_ENV
 from spyne.model import PushBase, ComplexModelBase, AnyXml, Fault, AnyDict, \
-    AnyHtml, ModelBase, ByteArray, XmlData, Any, AnyUri, ImageUri
+    AnyHtml, ModelBase, ByteArray, XmlData, Any, AnyUri, ImageUri, XmlAttribute
+
 from spyne.model.enum import EnumBase
 from spyne.protocol import OutProtocolBase
 from spyne.protocol.xml import SchemaValidationError
@@ -389,7 +390,8 @@ class ToParentMixin(OutProtocolBase):
         parent_cls = getattr(cls, '__extends__', None)
 
         if not (parent_cls is None):
-            ret = self._write_members(ctx, parent_cls, inst, parent, **kwargs)
+            ret = self._write_members(ctx, parent_cls, inst, parent,
+                                                        use_ns=use_ns, **kwargs)
             if ret is not None:
                 try:
                     while True:
@@ -407,6 +409,9 @@ class ToParentMixin(OutProtocolBase):
             if attr.exc:
                 prot_name = self.__class__.__name__
                 logger.debug("%s: excluded for %s.", k, prot_name)
+                continue
+
+            if issubclass(v, XmlAttribute):
                 continue
 
             try:  # e.g. SqlAlchemy could throw NoSuchColumnError
@@ -452,8 +457,10 @@ class ToParentMixin(OutProtocolBase):
     def complex_to_parent(self, ctx, cls, inst, parent, name, **kwargs):
         inst = cls.get_serialization_instance(inst)
 
-        # TODO: Put xml attributes as well in the below element() call.
-        with parent.element(name):
+        attrs = self._gen_attr_dict(inst, cls.get_flat_type_info(cls))
+
+        with parent.element(name, attrib=attrs):
+            parent.write(" ")
             ret = self._write_members(ctx, cls, inst, parent, **kwargs)
             if ret is not None:
                 try:

--- a/spyne/protocol/soap/mime.py
+++ b/spyne/protocol/soap/mime.py
@@ -42,9 +42,9 @@ from email import message_from_string
 from spyne.model.binary import Attachment
 from spyne.model.binary import ByteArray
 
-import spyne.const.xml_ns
-_ns_xop = spyne.const.xml_ns.xop
-_ns_soap_env = spyne.const.xml_ns.soap11_env
+import spyne.const.xml
+_ns_xop = spyne.const.xml.NS_XOP
+_ns_soap_env = spyne.const.xml.NS_SOAP11_ENV
 
 from spyne.util.six.moves.urllib.parse import unquote
 

--- a/spyne/protocol/soap/soap11.py
+++ b/spyne/protocol/soap/soap11.py
@@ -42,7 +42,7 @@ import cgi
 
 from itertools import chain
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 from lxml import etree
 from lxml.etree import XMLSyntaxError
@@ -50,7 +50,7 @@ from lxml.etree import XMLParser
 
 from spyne import BODY_STYLE_WRAPPED
 from spyne.util import six
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 from spyne.const.http import HTTP_405, HTTP_500
 from spyne.error import RequestNotAllowed
 from spyne.model.fault import Fault
@@ -63,7 +63,7 @@ from spyne.server.http import HttpTransportContext
 def _from_soap(in_envelope_xml, xmlids=None, **kwargs):
     """Parses the xml string into the header and payload.
     """
-    ns_soap = kwargs.pop('ns', ns.soap11_env)
+    ns_soap = kwargs.pop('ns', ns.NS_SOAP11_ENV)
 
     if xmlids:
         resolve_hrefs(in_envelope_xml, xmlids)

--- a/spyne/protocol/xml.py
+++ b/spyne/protocol/xml.py
@@ -825,7 +825,7 @@ class XmlDocument(SubXmlBase):
     def _fault_to_parent_impl(self, ctx, cls, inst, parent, ns, subelts, **_):
         tag_name = "{%s}Fault" % self.ns_soap_env
 
-        # Accepting raw lxml objects as detail is deprecated. It's also not
+        # Accepting raw lxml objects as detail is DEPRECATED. It's also not
         # documented. It's kept for backwards-compatibility purposes.
         if isinstance(inst.detail, string_types + (etree._Element,)):
             _append(subelts, E('detail', inst.detail))

--- a/spyne/protocol/xml.py
+++ b/spyne/protocol/xml.py
@@ -57,9 +57,8 @@ from spyne.error import ValidationError
 from spyne.const.ansi_color import LIGHT_GREEN
 from spyne.const.ansi_color import LIGHT_RED
 from spyne.const.ansi_color import END_COLOR
-from spyne.const.xml_ns import xsi as _ns_xsi
-from spyne.const.xml_ns import soap11_env
-from spyne.const.xml_ns import const_prefmap, DEFAULT_NS
+from spyne.const.xml import NS_SOAP11_ENV
+from spyne.const.xml import PREFMAP, DEFAULT_NS
 
 from spyne.model import Any
 from spyne.model import ModelBase
@@ -232,8 +231,8 @@ class XmlDocument(SubXmlBase):
     type = set(ProtocolBase.type)
     type.add('xml')
 
-    soap_env = const_prefmap[soap11_env]
-    ns_soap_env = soap11_env
+    soap_env = PREFMAP[NS_SOAP11_ENV]
+    ns_soap_env = NS_SOAP11_ENV
 
     def __init__(self, app=None, validator=None,
                 replace_null_with_default=True,
@@ -407,7 +406,7 @@ class XmlDocument(SubXmlBase):
         self.validate_body(ctx, message)
 
     def from_element(self, ctx, cls, element):
-        if bool(element.get('{%s}nil' % _ns_xsi)):
+        if bool(element.get(XSI('nil'))):
             if self.validator is self.SOFT_VALIDATION and not \
                                                         cls.Attributes.nillable:
                 raise ValidationError('')

--- a/spyne/test/interface/test_wsgi.py
+++ b/spyne/test/interface/test_wsgi.py
@@ -27,7 +27,7 @@ from spyne.server.wsgi import WsgiApplication
 from spyne.application import Application
 from spyne.model.primitive import Unicode
 from spyne.decorator import rpc
-from spyne.const.xml_ns import wsdl as NS_WSDL
+from spyne.const.xml import WSDL11
 from spyne.service import ServiceBase
 
 
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
 
         from lxml import etree
 
-        assert etree.fromstring(retval).tag == '{%s}definitions' % NS_WSDL
+        assert etree.fromstring(retval).tag == WSDL11('definitions')
 
 if __name__ == '__main__':
     unittest.main()

--- a/spyne/test/interface/test_xml_schema.py
+++ b/spyne/test/interface/test_xml_schema.py
@@ -25,7 +25,7 @@ from lxml import etree
 
 from spyne import Application
 from spyne import rpc
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 from spyne.const.xml import NS_XSD
 from spyne.model import ByteArray
 from spyne.model import ComplexModel
@@ -72,10 +72,10 @@ class TestXmlSchema(unittest.TestCase):
         print(etree.tostring(doc, pretty_print=True))
         assert len(doc.xpath('/xs:schema/xs:complexType[@name="SomeObject"]'
                                    '/xs:sequence/xs:element[@name="punk"]',
-            namespaces={'xs': ns.xsd})) > 0
+            namespaces={'xs': NS_XSD})) > 0
         assert len(doc.xpath('/xs:schema/xs:complexType[@name="SomeObject"]'
                     '/xs:sequence/xs:choice/xs:element[@name="one"]',
-            namespaces={'xs': ns.xsd})) > 0
+            namespaces={'xs': NS_XSD})) > 0
 
     def test_customized_class_with_empty_subclass(self):
         class SummaryStatsOfDouble(ComplexModel):
@@ -178,8 +178,8 @@ class TestXmlSchema(unittest.TestCase):
             out_protocol=Soap11()
         )
 
-        _ns = {'xs': ns.xsd}
-        pref_xs = ns.const_prefmap[ns.xsd]
+        _ns = {'xs': NS_XSD}
+        pref_xs = ns.PREFMAP[NS_XSD]
         xs = XmlSchema(app.interface)
         xs.build_interface_document()
         elt = xs.get_interface_document()['tns'].xpath(
@@ -216,16 +216,16 @@ class TestXmlSchema(unittest.TestCase):
         class SomeType(ComplexModel):
             __namespace__ = "zo"
 
-            anything = AnyXml(schema_tag='{%s}any' % ns.xsd, namespace='##other',
+            anything = AnyXml(schema_tag='{%s}any' % NS_XSD, namespace='##other',
                                                          process_contents='lax')
 
         docs = get_schema_documents([SomeType])
         print(etree.tostring(docs['tns'], pretty_print=True))
-        any = docs['tns'].xpath('//xsd:any', namespaces={'xsd': ns.xsd})
+        _any = docs['tns'].xpath('//xsd:any', namespaces={'xsd': NS_XSD})
 
-        assert len(any) == 1
-        assert any[0].attrib['namespace'] == '##other'
-        assert any[0].attrib['processContents'] == 'lax'
+        assert len(_any) == 1
+        assert _any[0].attrib['namespace'] == '##other'
+        assert _any[0].attrib['processContents'] == 'lax'
 
     def _build_xml_data_test_schema(self, custom_root):
         tns = 'kickass.ns'
@@ -268,7 +268,7 @@ class TestXmlSchema(unittest.TestCase):
         assert len(schema.get_interface_document()['tns'].xpath(
                 '/xs:schema/xs:complexType[@name="ProductEdition"]'
                 '/xs:simpleContent/xs:extension/xs:attribute[@name="id"]'
-                ,namespaces={'xs': ns.xsd})) == 1
+                ,namespaces={'xs': NS_XSD})) == 1
 
     def _test_xml_data_validation(self):
         schema = self._build_xml_data_test_schema(custom_root=False)
@@ -294,7 +294,7 @@ class TestXmlSchema(unittest.TestCase):
     def test_subs(self):
         from lxml import etree
         from spyne.util.xml import get_schema_documents
-        xpath = lambda o, x: o.xpath(x, namespaces={"xs": ns.xsd})
+        xpath = lambda o, x: o.xpath(x, namespaces={"xs": NS_XSD})
 
         m = {
             "s0": "aa",
@@ -325,7 +325,7 @@ class TestXmlSchema(unittest.TestCase):
         #assert len(xpath(seq, 'xs:element[@name="{dd}dd"]')) == 1
 
     def test_mandatory(self):
-        xpath = lambda o, x: o.xpath(x, namespaces={"xs": ns.xsd})
+        xpath = lambda o, x: o.xpath(x, namespaces={"xs": NS_XSD})
 
         class C(ComplexModel):
             __namespace__ = "aa"

--- a/spyne/test/interface/wsdl/__init__.py
+++ b/spyne/test/interface/wsdl/__init__.py
@@ -20,7 +20,7 @@
 from spyne.application import Application
 from spyne.interface.wsdl import Wsdl11
 from spyne.protocol.soap import Soap11
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 def build_app(service_list, tns, name):
     app = Application(service_list, tns, name=name,
@@ -32,12 +32,12 @@ class AppTestWrapper():
     def __init__(self, application):
 
         self.url = 'http:/localhost:7789/wsdl'
-        self.service_string = '{%s}service' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
-        self.soap_binding_string = '{%s}binding' % ns.soap
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
+        self.service_string = ns.WSDL11('service')
+        self.port_string = ns.WSDL11('port')
+        self.soap_binding_string = ns.WSDL11_SOAP('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_type_string = ns.WSDL11('portType')
+        self.binding_string = ns.WSDL11('binding')
 
         self.app = application
         self.interface_doc = Wsdl11(self.app.interface)

--- a/spyne/test/interface/wsdl/test_bindings.py
+++ b/spyne/test/interface/wsdl/test_bindings.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 import unittest
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 
 from spyne.interface.wsdl.wsdl11 import Wsdl11
@@ -36,11 +36,11 @@ class TestWSDLBindingBehavior(unittest.TestCase):
     def setUp(self):
         self.transport = 'http://schemas.xmlsoap.org/soap/http'
         self.url = 'http:/localhost:7789/wsdl'
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.service_string = '{%s}service' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
+        self.port_type_string = ns.WSDL11('portType')
+        self.service_string = ns.WSDL11('service')
+        self.binding_string = ns.WSDL11('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_string = ns.WSDL11('port')
 
     def test_binding_simple(self):
         sa = build_app([TS1()], 'S1Port', 'TestServiceName')

--- a/spyne/test/interface/wsdl/test_default_wsdl.py
+++ b/spyne/test/interface/wsdl/test_default_wsdl.py
@@ -36,7 +36,7 @@ from spyne.const import REQUEST_SUFFIX
 from spyne.const import RESPONSE_SUFFIX
 from spyne.const import ARRAY_SUFFIX
 
-from spyne.const.xml_ns import const_nsmap
+from spyne.const.xml import NSMAP
 from spyne.decorator import srpc
 from spyne.service import ServiceBase
 from spyne.interface.wsdl import Wsdl11

--- a/spyne/test/interface/wsdl/test_op_req_suffix.py
+++ b/spyne/test/interface/wsdl/test_op_req_suffix.py
@@ -30,6 +30,7 @@ from spyne.protocol.http import HttpRpc
 from spyne.protocol.json import JsonDocument
 from spyne.server.wsgi import WsgiApplication
 
+from spyne.const.xml import PREFMAP, NS_WSDL11_SOAP
 
 def strip_whitespace(string):
     return ''.join(string.split())
@@ -162,7 +163,7 @@ class TestOperationRequestSuffix(unittest.TestCase):
 
         soap_strings = [
             '<wsdl:operation name="{0}"'.format(operation_name),
-            '<soap:operation soapAction="{0}"'.format(operation_name),
+            '<{0}:operation soapAction="{1}"'.format(PREFMAP[NS_WSDL11_SOAP], operation_name),
             '<wsdl:input name="{0}">'.format(request_name),
             '<xs:element name="{0}"'.format(request_name),
             '<xs:complexType name="{0}">'.format(request_name),

--- a/spyne/test/interface/wsdl/test_wsdl_ports_services.py
+++ b/spyne/test/interface/wsdl/test_wsdl_ports_services.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 import unittest
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 from spyne.test.interface.wsdl import AppTestWrapper
 from spyne.test.interface.wsdl import build_app
@@ -37,11 +37,11 @@ class TestWSDLPortServiceBehavior(unittest.TestCase):
     def setUp(self):
         self.transport = 'http://schemas.xmlsoap.org/soap/http'
         self.url = 'http:/localhost:7789/wsdl'
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.service_string = '{%s}service' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
+        self.port_type_string = ns.WSDL11('portType')
+        self.service_string = ns.WSDL11('service')
+        self.binding_string = ns.WSDL11('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_string = ns.WSDL11('port')
 
     def test_tns(self):
         sa = build_app([TSinglePortService()], 'SinglePort', 'TestServiceName')

--- a/spyne/test/interop/test_zeep.py
+++ b/spyne/test/interop/test_zeep.py
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 #
 import logging
-from copy import copy, deepcopy
 
 zeep_logger = logging.getLogger('zeep')
 zeep_logger.setLevel(logging.INFO)
@@ -223,9 +222,7 @@ class TestZeep(unittest.TestCase):
         val.i = 45
         val.s = "asd"
 
-        # why val loses all its data after being passed to service request?
-        # it doesn't work without deepcopy!
-        ret = self.client.service.echo_simple_class(deepcopy(val))
+        ret = self.client.service.echo_simple_class(val)
 
         assert ret.i == val.i
         assert ret.s == val.s
@@ -238,9 +235,7 @@ class TestZeep(unittest.TestCase):
         val.sr.i = 50
         val.sr.sr = None
 
-        # why val loses all its data after being passed to service request?
-        # it doesn't work without deepcopy!
-        ret = self.client.service.echo_class_with_self_reference(deepcopy(val))
+        ret = self.client.service.echo_class_with_self_reference(val)
 
         assert ret.i == val.i
         assert ret.sr.i == val.sr.i
@@ -269,9 +264,7 @@ class TestZeep(unittest.TestCase):
         val.other.d = 123.456
         val.other.b = True
 
-        # why val loses all its data after being passed to service request?
-        # it doesn't work without deepcopy!
-        ret = self.client.service.echo_nested_class(deepcopy(val))
+        ret = self.client.service.echo_nested_class(val)
 
         self.assertEquals(ret.i, val.i)
         self.assertEqual(ret.ai.integer, val.ai.integer)
@@ -319,9 +312,7 @@ class TestZeep(unittest.TestCase):
         val.l = datetime(2010, 7, 2)
         val.q = 5
 
-        # why val loses all its data after being passed to service request?
-        # it doesn't work without deepcopy!
-        ret = self.client.service.echo_extension_class(deepcopy(val))
+        ret = self.client.service.echo_extension_class(val)
         print(ret)
 
         self.assertEquals(ret.i, val.i)

--- a/spyne/test/interop/test_zeep.py
+++ b/spyne/test/interop/test_zeep.py
@@ -365,38 +365,9 @@ class TestZeep(unittest.TestCase):
 
         assert ret == 'test'
 
-    #
-    # This test is disabled because zeep does not create the right request
-    # object. Opening the first <ns0:string> tag below is wrong.
-    #
-    #<SOAP-ENV:Envelope xmlns:ns0="spyne.test.interop.server"
-    #                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    #                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    #                   xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/"
-    #                   xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-    #  <SOAP-ENV:Header/>
-    #  <ns1:Body>
-    #      <ns0:echo_complex_bare>
-    #         <ns0:string>
-    #            <ns0:string>abc</ns0:string>
-    #            <ns0:string>def</ns0:string>
-    #         </ns0:string>
-    #      </ns0:echo_complex_bare>
-    #  </ns1:Body>
-    #</SOAP-ENV:Envelope>
-    #
-    # The right request looks like this:
-    #
-    #      <ns0:echo_complex_bare>
-    #         <ns0:string>abc</ns0:string>
-    #         <ns0:string>def</ns0:string>
-    #      </ns0:echo_complex_bare>
-    #
-    def _test_echo_complex_bare(self):
+    def test_echo_complex_bare(self):
         val = ['abc','def']
-        ia = self.client.get_type('{%s}stringArray' % self.ns)()
-        ia.string.extend(val)
-        ret = self.client.service.echo_complex_bare(ia)
+        ret = self.client.service.echo_complex_bare(val)
 
         assert ret == val
 

--- a/spyne/test/interop/test_zeep.py
+++ b/spyne/test/interop/test_zeep.py
@@ -126,23 +126,22 @@ class TestZeep(unittest.TestCase):
         ia.integer.extend([1, 2, 3, 4, 5])
         self.client.service.echo_integer_array(ia)
 
-    # FIXME: Figure how this is supposed to work
-    def _test_echo_in_header(self):
+    def test_echo_in_header(self):
         in_header = self.client.get_type('{%s}InHeader' % self.ns)()
         in_header.s = 'a'
         in_header.i = 3
 
-        self.client.set_options(soapheaders=in_header)
-        ret = self.client.service.echo_in_header()
-        self.client.set_options(soapheaders=None)
+        ret = self.client.service.echo_in_header(_soapheaders={
+            'InHeader': in_header,
+        })
 
         print(ret)
 
-        self.assertEquals(in_header.s, ret.s)
-        self.assertEquals(in_header.i, ret.i)
+        out_header = ret.body.echo_in_headerResult
+        self.assertEquals(in_header.s, out_header.s)
+        self.assertEquals(in_header.i, out_header.i)
 
-    # FIXME: Figure how this is supposed to work
-    def _test_echo_in_complex_header(self):
+    def test_echo_in_complex_header(self):
         in_header = self.client.get_type('{%s}InHeader' % self.ns)()
         in_header.s = 'a'
         in_header.i = 3
@@ -151,16 +150,20 @@ class TestZeep(unittest.TestCase):
         in_trace_header.callDate = datetime(year=2000, month=1, day=1, hour=0,
                                               minute=0, second=0, microsecond=0)
 
-        self.client.set_options(soapheaders=(in_header, in_trace_header))
-        ret = self.client.service.echo_in_complex_header()
-        self.client.set_options(soapheaders=None)
+        ret = self.client.service.echo_in_complex_header(_soapheaders={
+            'InHeader': in_header,
+            'InTraceHeader': in_trace_header
+        })
 
         print(ret)
 
-        self.assertEquals(in_header.s, ret[0].s)
-        self.assertEquals(in_header.i, ret[0].i)
-        self.assertEquals(in_trace_header.client, ret[1].client)
-        self.assertEquals(in_trace_header.callDate, ret[1].callDate)
+        out_header = ret.body.echo_in_complex_headerResult0
+        out_trace_header = ret.body.echo_in_complex_headerResult1
+
+        self.assertEquals(in_header.s, out_header.s)
+        self.assertEquals(in_header.i, out_header.i)
+        self.assertEquals(in_trace_header.client, out_trace_header.client)
+        self.assertEquals(in_trace_header.callDate, out_trace_header.callDate)
 
     def test_send_out_header(self):
         out_header = self.client.get_type('{%s}OutHeader' % self.ns)()

--- a/spyne/test/interop/test_zeep.py
+++ b/spyne/test/interop/test_zeep.py
@@ -47,15 +47,13 @@ class TestZeep(unittest.TestCase):
         return self.client.get_type(what)()
 
     def test_echo_datetime(self):
-        # ZEEP doesn't support microseconds
-        val = datetime.now().replace(microsecond=0)
+        val = datetime.now()
         ret = self.client.service.echo_datetime(val)
 
         assert val == ret
 
     def test_echo_datetime_with_invalid_format(self):
-        # ZEEP doesn't support microseconds
-        val = datetime.now().replace(microsecond=0)
+        val = datetime.now()
         ret = self.client.service.echo_datetime_with_invalid_format(val)
 
         assert val == ret
@@ -73,15 +71,13 @@ class TestZeep(unittest.TestCase):
         assert val == ret
 
     def test_echo_time(self):
-        # ZEEP doesnt support microseconds
-        val = datetime.now().replace(microsecond=0).time()
+        val = datetime.now().time()
         ret = self.client.service.echo_time(val)
 
         assert val == ret
 
     def test_echo_time_with_invalid_format(self):
-        # ZEEP doesnt support microseconds
-        val = datetime.now().replace(microsecond=0).time()
+        val = datetime.now().time()
         ret = self.client.service.echo_time_with_invalid_format(val)
 
         assert val == ret
@@ -269,8 +265,7 @@ class TestZeep(unittest.TestCase):
         val.simple.SimpleClass[1].s = "qwe"
 
         val.other = self.client.get_type("{%s}OtherClass" % self.ns)()
-        # ZEEP doesn't support microseconds
-        val.other.dt = datetime.now().replace(microsecond=0)
+        val.other.dt = datetime.now()
         val.other.d = 123.456
         val.other.b = True
 
@@ -312,8 +307,7 @@ class TestZeep(unittest.TestCase):
         val.simple.SimpleClass[1].s = "qwe"
 
         val.other = self.client.get_type("{%s}OtherClass" % self.ns)()
-        # ZEEP doesn't support microseconds
-        val.other.dt = datetime.now().replace(microsecond=0)
+        val.other.dt = datetime.now()
         val.other.d = 123.456
         val.other.b = True
 

--- a/spyne/test/interop/test_zeep.py
+++ b/spyne/test/interop/test_zeep.py
@@ -30,6 +30,7 @@ from base64 import b64encode, b64decode
 from spyne.util import six
 
 from zeep import Client
+from zeep.transports import Transport
 from zeep.exceptions import Error as ZeepError
 
 
@@ -38,7 +39,8 @@ class TestZeep(unittest.TestCase):
         from spyne.test.interop._test_soap_client_base import run_server
         run_server('http')
 
-        self.client = Client("http://localhost:9754/?wsdl")
+        transport = Transport(cache=False)
+        self.client = Client("http://localhost:9754/?wsdl", transport=transport)
         self.ns = "spyne.test.interop.server"
 
     def get_inst(self, what):

--- a/spyne/test/model/test_binary.py
+++ b/spyne/test/model/test_binary.py
@@ -23,9 +23,9 @@ from lxml import etree
 from spyne.protocol.soap import Soap11
 from spyne.model.binary import ByteArray
 from spyne.model.binary import _bytes_join
-import spyne.const.xml_ns
+import spyne.const.xml
 
-ns_xsd = spyne.const.xml_ns.xsd
+ns_xsd = spyne.const.xml.NS_XSD
 ns_test = 'test_namespace'
 
 

--- a/spyne/test/model/test_complex.py
+++ b/spyne/test/model/test_complex.py
@@ -33,7 +33,7 @@ from decimal import Decimal as D
 from spyne import Application, rpc, mrpc, ServiceBase, ByteArray, Array, \
     ComplexModel, SelfReference, XmlData, XmlAttribute, Unicode, DateTime, \
     Float, Integer, String
-from spyne.const import xml_ns
+from spyne.const import xml
 from spyne.error import ResourceNotFoundError
 from spyne.interface import Interface
 from spyne.interface.wsdl import Wsdl11
@@ -409,7 +409,7 @@ class TestXmlAttribute(unittest.TestCase):
         wsdl.build_interface_document('http://a-aaaa.com')
         pref = CM.get_namespace_prefix(interface)
         type_def = wsdl.get_schema_info(pref).types[CM.get_type_name()]
-        attribute_def = type_def.find('{%s}attribute' % xml_ns.xsd)
+        attribute_def = type_def.find(xml.XSD('attribute'))
         print(etree.tostring(type_def, pretty_print=True))
 
         self.assertIsNotNone(attribute_def)

--- a/spyne/test/model/test_enum.py
+++ b/spyne/test/model/test_enum.py
@@ -22,7 +22,7 @@ import unittest
 from pprint import pprint
 
 from spyne.application import Application
-from spyne.const.xml_ns import xsd as _ns_xsd
+from spyne.const.xml import XSD
 from spyne.interface.wsdl.wsdl11 import Wsdl11
 from spyne.model.complex import Array
 from spyne.model.complex import ComplexModel
@@ -88,7 +88,7 @@ class TestEnum(unittest.TestCase):
         print(simple_type)
 
         self.assertEquals(simple_type.attrib['name'], 'DaysOfWeekEnum')
-        self.assertEquals(simple_type[0].tag, "{%s}restriction" % _ns_xsd)
+        self.assertEquals(simple_type[0].tag, XSD("restriction"))
         self.assertEquals([e.attrib['value'] for e in simple_type[0]], vals)
 
     def test_serialize(self):

--- a/spyne/test/model/test_exception.py
+++ b/spyne/test/model/test_exception.py
@@ -53,9 +53,9 @@ class FaultTests(unittest.TestCase):
 
     def test_to_parent_wo_detail(self):
         from lxml.etree import Element
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
-        soap_env = spyne.const.xml_ns.const_prefmap[spyne.const.xml_ns.soap11_env]
+        import spyne.const.xml
+        ns_soap_env = spyne.const.xml.NS_SOAP11_ENV
+        soap_env = spyne.const.xml.PREFMAP[spyne.const.xml.NS_SOAP11_ENV]
 
         element = Element('testing')
         fault = Fault()
@@ -85,10 +85,10 @@ class FaultTests(unittest.TestCase):
     def test_from_xml_wo_detail(self):
         from lxml.etree import Element
         from lxml.etree import SubElement
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
-        soap_env = spyne.const.xml_ns.const_prefmap[spyne.const.xml_ns.soap11_env]
-        element = Element('{%s}Fault' % ns_soap_env)
+        from spyne.const.xml import PREFMAP, SOAP11_ENV, NS_SOAP11_ENV
+
+        soap_env = PREFMAP[NS_SOAP11_ENV]
+        element = Element(SOAP11_ENV('Fault'))
 
         fcode = SubElement(element, 'faultcode')
         fcode.text = '%s:other' % soap_env
@@ -107,10 +107,9 @@ class FaultTests(unittest.TestCase):
     def test_from_xml_w_detail(self):
         from lxml.etree import Element
         from lxml.etree import SubElement
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
+        from spyne.const.xml import SOAP11_ENV
 
-        element = Element('{%s}Fault' % ns_soap_env)
+        element = Element(SOAP11_ENV('Fault'))
         fcode = SubElement(element, 'faultcode')
         fcode.text = 'soap11env:other'
         fstr = SubElement(element, 'faultstring')
@@ -124,8 +123,7 @@ class FaultTests(unittest.TestCase):
         self.failUnless(fault.detail is detail)
 
     def test_add_to_schema_no_extends(self):
-        import spyne.const.xml_ns
-        ns_xsd = spyne.const.xml_ns.xsd
+        from spyne.const.xml import XSD
 
         class cls(Fault):
             __namespace__='ns'
@@ -145,19 +143,18 @@ class FaultTests(unittest.TestCase):
         c_cls = interface.classes['{ns}cls']
         c_elt = schema.types[0]
         self.failUnless(c_cls is cls)
-        self.assertEqual(c_elt.tag, '{%s}complexType' % ns_xsd)
+        self.assertEqual(c_elt.tag, XSD('complexType'))
         self.assertEqual(c_elt.get('name'), 'cls')
 
         self.assertEqual(len(schema.elements), 1)
         e_elt = schema.elements.values()[0]
-        self.assertEqual(e_elt.tag, '{%s}element' % ns_xsd)
+        self.assertEqual(e_elt.tag, XSD('element'))
         self.assertEqual(e_elt.get('name'), 'cls')
         self.assertEqual(e_elt.get('type'), 'testing:My')
         self.assertEqual(len(e_elt), 0)
 
     def test_add_to_schema_w_extends(self):
-        import spyne.const.xml_ns
-        ns_xsd = spyne.const.xml_ns.xsd
+        from spyne.const.xml import XSD
 
         class base(Fault):
             __namespace__ = 'ns'
@@ -185,7 +182,7 @@ class FaultTests(unittest.TestCase):
         c_elt = next(iter(schema.types.values()))
 
         self.failUnless(c_cls is cls)
-        self.assertEqual(c_elt.tag, '{%s}complexType' % ns_xsd)
+        self.assertEqual(c_elt.tag, XSD('complexType'))
         self.assertEqual(c_elt.get('name'), 'cls')
 
         from lxml import etree

--- a/spyne/test/model/test_include.py
+++ b/spyne/test/model/test_include.py
@@ -30,7 +30,7 @@ from spyne.model.primitive import Integer
 from spyne.model.primitive import String
 from spyne.protocol.xml import XmlDocument
 from spyne.protocol.soap.mime import _join_attachment
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 
 # Service Classes
 class DownloadPartFileResult(ComplexModel):
@@ -64,7 +64,7 @@ class TestInclude(unittest.TestCase):
 
         soaptree = etree.fromstring(joinedmsg)
 
-        body = soaptree.find("{%s}Body" % ns.soap11_env)
+        body = soaptree.find(ns.SOAP11_ENV("Body"))
         response = body.getchildren()[0]
         result = response.getchildren()[0]
         r = XmlDocument().from_element(None, DownloadPartFileResult, result)

--- a/spyne/test/model/test_primitive.py
+++ b/spyne/test/model/test_primitive.py
@@ -33,7 +33,7 @@ from datetime import timedelta
 from lxml import etree
 
 from spyne.util import six, total_seconds
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 
 from spyne import Null, AnyDict, Uuid, Array, ComplexModel, Date, Time, \
     Boolean, DateTime, Duration, Float, Integer, UnsignedInteger, Unicode, \
@@ -492,7 +492,7 @@ class TestPrimitive(unittest.TestCase):
         print(etree.tostring(element))
 
         element = element[0]
-        self.assertTrue(bool(element.attrib.get('{%s}nil' % ns.xsi)))
+        self.assertTrue(bool(element.attrib.get(ns.XSI('nil'))))
         value = XmlDocument().from_element(None, Null, element)
         self.assertEquals(None, value)
 
@@ -574,7 +574,7 @@ class TestPrimitive(unittest.TestCase):
         b = etree.Element('test')
         XmlDocument().to_parent(None, Boolean, None, b, ns_test)
         b = b[0]
-        self.assertEquals('true', b.get('{%s}nil' % ns.xsi))
+        self.assertEquals('true', b.get(ns.XSI('nil')))
 
         b = XmlDocument().from_element(None, Boolean, b)
         self.assertEquals(b, None)

--- a/spyne/test/model/test_primitive.py
+++ b/spyne/test/model/test_primitive.py
@@ -29,6 +29,7 @@ import pytz
 
 from datetime import timedelta
 
+import spyne
 from lxml import etree
 
 from spyne.util import six, total_seconds
@@ -283,6 +284,58 @@ class TestPrimitive(unittest.TestCase):
         self.assertEquals(dt.year, 2007)
         self.assertEquals(dt.month, 5)
         self.assertEquals(dt.day, 15)
+
+    def test_date_exclusive_boundaries(self):
+        test_model = Date.customize(gt=datetime.date(2016, 1, 1), lt=datetime.date(2016, 2, 1))
+        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+
+    def test_date_inclusive_boundaries(self):
+        test_model = Date.customize(ge=datetime.date(2016, 1, 1), le=datetime.date(2016, 2, 1))
+        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+
+    def test_datetime_exclusive_boundaries(self):
+        test_model = DateTime.customize(
+            gt=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
+            lt=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+        self.assertFalse(test_model.validate_native(test_model,
+                                                    datetime.datetime(2016, 1, 1, 12, 00)))
+        self.assertFalse(test_model.validate_native(test_model,
+                                                    datetime.datetime(2016, 2, 1, 12, 00)))
+
+    def test_datetime_inclusive_boundaries(self):
+        test_model = DateTime.customize(
+            ge=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
+            le=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+        self.assertTrue(test_model.validate_native(test_model,
+                                                   datetime.datetime(2016, 1, 1, 12, 00)))
+        self.assertTrue(test_model.validate_native(test_model,
+                                                   datetime.datetime(2016, 2, 1, 12, 00)))
+
+    def test_time_exclusive_boundaries(self):
+        test_model = Time.customize(gt=datetime.time(12, 00),
+                                    lt=datetime.time(13, 00))
+        self.assertFalse(test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertFalse(test_model.validate_native(test_model, datetime.time(13, 00)))
+
+    def test_time_inclusive_boundaries(self):
+        test_model = Time.customize(ge=datetime.time(12, 00),
+                                    le=datetime.time(13, 00))
+        self.assertTrue(test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertTrue(test_model.validate_native(test_model, datetime.time(13, 00)))
+
+    def test_datetime_extreme_boundary(self):
+        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.min))
+        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.max))
+
+    def test_time_extreme_boundary(self):
+        self.assertTrue(Time.validate_native(Time, datetime.time(0,0,0,0)))
+        self.assertTrue(Time.validate_native(Time, datetime.time(23, 59, 59, 999999)))
+
+    def test_date_extreme_boundary(self):
+        self.assertTrue(Date.validate_native(Date, datetime.date.min))
+        self.assertTrue(Date.validate_native(Date, datetime.date.max))
 
     def test_integer(self):
         i = 12

--- a/spyne/test/model/test_primitive.py
+++ b/spyne/test/model/test_primitive.py
@@ -26,10 +26,10 @@ import datetime
 import unittest
 
 import pytz
+import spyne
 
 from datetime import timedelta
 
-import spyne
 from lxml import etree
 
 from spyne.util import six, total_seconds
@@ -65,6 +65,7 @@ class TestPrimitive(unittest.TestCase):
 
     def test_nillable_quirks(self):
         assert ModelBase.Attributes.nillable == True
+
         class Attributes(ModelBase.Attributes):
             nillable = False
             nullable = False
@@ -98,8 +99,10 @@ class TestPrimitive(unittest.TestCase):
 
         class Attributes(ModelBase.Attributes):
             nullable = False
+
         class Attributes(Attributes):
             pass
+
         assert Attributes.nullable == False
 
     def test_nillable_inheritance_quirks(self):
@@ -108,26 +111,30 @@ class TestPrimitive(unittest.TestCase):
 
         class AttrMixin:
             pass
+
         class NewAttributes(Attributes, AttrMixin):
             pass
+
         assert NewAttributes.nullable is False
 
         class AttrMixin:
             pass
+
         class NewAttributes(AttrMixin, Attributes):
             pass
 
         assert NewAttributes.nullable is False
 
     def test_decimal(self):
-        assert Decimal(10,4).Attributes.total_digits == 10
-        assert Decimal(10,4).Attributes.fraction_digits == 4
+        assert Decimal(10, 4).Attributes.total_digits == 10
+        assert Decimal(10, 4).Attributes.fraction_digits == 4
 
     def test_decimal_format(self):
         f = 123456
-        str_format='${0}'
+        str_format = '${0}'
         element = etree.Element('test')
-        XmlDocument().to_parent(None, Decimal(str_format=str_format), f, element, ns_test)
+        XmlDocument().to_parent(None, Decimal(str_format=str_format), f,
+                                                               element, ns_test)
         element = element[0]
 
         self.assertEquals(element.text, '$123456')
@@ -136,7 +143,7 @@ class TestPrimitive(unittest.TestCase):
         s = String()
         element = etree.Element('test')
         XmlDocument().to_parent(None, String, 'value', element, ns_test)
-        element=element[0]
+        element = element[0]
 
         self.assertEquals(element.text, 'value')
         value = XmlDocument().from_element(None, String, element)
@@ -158,7 +165,8 @@ class TestPrimitive(unittest.TestCase):
         format = "%Y %m %d %H %M %S"
 
         element = etree.Element('test')
-        XmlDocument().to_parent(None, DateTime(format=format), n, element, ns_test)
+        XmlDocument().to_parent(None, DateTime(format=format), n, element,
+                                                                        ns_test)
         element = element[0]
 
         assert element.text == datetime.datetime.strftime(n, format)
@@ -256,7 +264,7 @@ class TestPrimitive(unittest.TestCase):
         self.assertEquals(datetime.time(12, 12, 12, 999999), t)
 
     def test_date(self):
-        n = datetime.date(2011,12,13)
+        n = datetime.date(2011, 12, 13)
 
         ret = ProtocolBase().to_unicode(Date, n)
         self.assertEquals(ret, n.isoformat())
@@ -286,52 +294,74 @@ class TestPrimitive(unittest.TestCase):
         self.assertEquals(dt.day, 15)
 
     def test_date_exclusive_boundaries(self):
-        test_model = Date.customize(gt=datetime.date(2016, 1, 1), lt=datetime.date(2016, 2, 1))
-        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
-        self.assertFalse(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+        test_model = Date.customize(gt=datetime.date(2016, 1, 1),
+            lt=datetime.date(2016, 2, 1))
+        self.assertFalse(
+              test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertFalse(
+              test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
 
     def test_date_inclusive_boundaries(self):
-        test_model = Date.customize(ge=datetime.date(2016, 1, 1), le=datetime.date(2016, 2, 1))
-        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
-        self.assertTrue(test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
+        test_model = Date.customize(ge=datetime.date(2016, 1, 1),
+            le=datetime.date(2016, 2, 1))
+        self.assertTrue(
+              test_model.validate_native(test_model, datetime.date(2016, 1, 1)))
+        self.assertTrue(
+              test_model.validate_native(test_model, datetime.date(2016, 2, 1)))
 
     def test_datetime_exclusive_boundaries(self):
         test_model = DateTime.customize(
-            gt=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
-            lt=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+            gt=datetime.datetime(2016, 1, 1, 12, 00)
+                                                .replace(tzinfo=spyne.LOCAL_TZ),
+            lt=datetime.datetime(2016, 2, 1, 12, 00)
+                                                .replace(tzinfo=spyne.LOCAL_TZ),
+        )
         self.assertFalse(test_model.validate_native(test_model,
-                                                    datetime.datetime(2016, 1, 1, 12, 00)))
+                                         datetime.datetime(2016, 1, 1, 12, 00)))
         self.assertFalse(test_model.validate_native(test_model,
-                                                    datetime.datetime(2016, 2, 1, 12, 00)))
+                                         datetime.datetime(2016, 2, 1, 12, 00)))
 
     def test_datetime_inclusive_boundaries(self):
         test_model = DateTime.customize(
-            ge=datetime.datetime(2016, 1, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ),
-            le=datetime.datetime(2016, 2, 1, 12, 00).replace(tzinfo=spyne.LOCAL_TZ))
+            ge=datetime.datetime(2016, 1, 1, 12, 00)
+                                                .replace(tzinfo=spyne.LOCAL_TZ),
+            le=datetime.datetime(2016, 2, 1, 12, 00)
+                                                .replace(tzinfo=spyne.LOCAL_TZ)
+        )
+
         self.assertTrue(test_model.validate_native(test_model,
-                                                   datetime.datetime(2016, 1, 1, 12, 00)))
+                                         datetime.datetime(2016, 1, 1, 12, 00)))
         self.assertTrue(test_model.validate_native(test_model,
-                                                   datetime.datetime(2016, 2, 1, 12, 00)))
+                                         datetime.datetime(2016, 2, 1, 12, 00)))
 
     def test_time_exclusive_boundaries(self):
         test_model = Time.customize(gt=datetime.time(12, 00),
-                                    lt=datetime.time(13, 00))
-        self.assertFalse(test_model.validate_native(test_model, datetime.time(12, 00)))
-        self.assertFalse(test_model.validate_native(test_model, datetime.time(13, 00)))
+                                                       lt=datetime.time(13, 00))
+
+        self.assertFalse(
+            test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertFalse(
+            test_model.validate_native(test_model, datetime.time(13, 00)))
 
     def test_time_inclusive_boundaries(self):
         test_model = Time.customize(ge=datetime.time(12, 00),
-                                    le=datetime.time(13, 00))
-        self.assertTrue(test_model.validate_native(test_model, datetime.time(12, 00)))
-        self.assertTrue(test_model.validate_native(test_model, datetime.time(13, 00)))
+                                                       le=datetime.time(13, 00))
+
+        self.assertTrue(
+                  test_model.validate_native(test_model, datetime.time(12, 00)))
+        self.assertTrue(
+                  test_model.validate_native(test_model, datetime.time(13, 00)))
 
     def test_datetime_extreme_boundary(self):
-        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.min))
-        self.assertTrue(DateTime.validate_native(DateTime, datetime.datetime.max))
+        self.assertTrue(
+                      DateTime.validate_native(DateTime, datetime.datetime.min))
+        self.assertTrue(
+                      DateTime.validate_native(DateTime, datetime.datetime.max))
 
     def test_time_extreme_boundary(self):
-        self.assertTrue(Time.validate_native(Time, datetime.time(0,0,0,0)))
-        self.assertTrue(Time.validate_native(Time, datetime.time(23, 59, 59, 999999)))
+        self.assertTrue(Time.validate_native(Time, datetime.time(0, 0, 0, 0)))
+        self.assertTrue(
+                  Time.validate_native(Time, datetime.time(23, 59, 59, 999999)))
 
     def test_date_extreme_boundary(self):
         self.assertTrue(Date.validate_native(Date, datetime.date.min))
@@ -351,13 +381,15 @@ class TestPrimitive(unittest.TestCase):
 
     def test_limits(self):
         try:
-            ProtocolBase().from_string(Integer, "1" * (Integer.__max_str_len__ + 1))
+            ProtocolBase() \
+                      .from_string(Integer, "1" * (Integer.__max_str_len__ + 1))
         except:
             pass
         else:
             raise Exception("must fail.")
 
-        ProtocolBase().from_string(UnsignedInteger, "-1") # This is not supposed to fail.
+        ProtocolBase().from_string(UnsignedInteger, "-1")
+                                                 # This is not supposed to fail.
 
         assert not UnsignedInteger.validate_native(UnsignedInteger, -1)
 
@@ -460,14 +492,14 @@ class TestPrimitive(unittest.TestCase):
         print(etree.tostring(element))
 
         element = element[0]
-        self.assertTrue( bool(element.attrib.get('{%s}nil' % ns.xsi)) )
+        self.assertTrue(bool(element.attrib.get('{%s}nil' % ns.xsi)))
         value = XmlDocument().from_element(None, Null, element)
         self.assertEquals(None, value)
 
     def test_point(self):
         from spyne.model.primitive.spatial import _get_point_pattern
 
-        a=re.compile(_get_point_pattern(2))
+        a = re.compile(_get_point_pattern(2))
         assert a.match('POINT (10 40)') is not None
         assert a.match('POINT(10 40)') is not None
 
@@ -477,34 +509,35 @@ class TestPrimitive(unittest.TestCase):
     def test_multipoint(self):
         from spyne.model.primitive.spatial import _get_multipoint_pattern
 
-        a=re.compile(_get_multipoint_pattern(2))
+        a = re.compile(_get_multipoint_pattern(2))
         assert a.match('MULTIPOINT (10 40, 40 30, 20 20, 30 10)') is not None
         # FIXME:
-        #assert a.match('MULTIPOINT ((10 40), (40 30), (20 20), (30 10))') is not None
+        # assert a.match('MULTIPOINT ((10 40), (40 30), (20 20), (30 10))') is not None
 
     def test_linestring(self):
         from spyne.model.primitive.spatial import _get_linestring_pattern
 
-        a=re.compile(_get_linestring_pattern(2))
+        a = re.compile(_get_linestring_pattern(2))
         assert a.match('LINESTRING (30 10, 10 30, 40 40)') is not None
 
     def test_multilinestring(self):
         from spyne.model.primitive.spatial import _get_multilinestring_pattern
 
-        a=re.compile(_get_multilinestring_pattern(2))
+        a = re.compile(_get_multilinestring_pattern(2))
         assert a.match('''MULTILINESTRING ((10 10, 20 20, 10 40),
                                 (40 40, 30 30, 40 20, 30 10))''') is not None
 
     def test_polygon(self):
         from spyne.model.primitive.spatial import _get_polygon_pattern
 
-        a=re.compile(_get_polygon_pattern(2))
-        assert a.match('POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))') is not None
+        a = re.compile(_get_polygon_pattern(2))
+        assert a.match(
+                    'POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))') is not None
 
     def test_multipolygon(self):
         from spyne.model.primitive.spatial import _get_multipolygon_pattern
 
-        a=re.compile(_get_multipolygon_pattern(2))
+        a = re.compile(_get_multipolygon_pattern(2))
         assert a.match('''MULTIPOLYGON (((30 20, 10 40, 45 40, 30 20)),
                             ((15 5, 40 10, 10 20, 5 10, 15 5)))''') is not None
         assert a.match('''MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),
@@ -569,7 +602,8 @@ class TestPrimitive(unittest.TestCase):
 
     def test_anydict_customization(self):
         from spyne.model import json
-        assert isinstance(AnyDict.customize(store_as='json').Attributes.store_as, json)
+        assert isinstance(
+                   AnyDict.customize(store_as='json').Attributes.store_as, json)
 
     def test_uuid_serialize(self):
         value = uuid.UUID('12345678123456781234567812345678')
@@ -660,7 +694,7 @@ class TestPrimitive(unittest.TestCase):
 
     def test_custom_strftime(self):
         s = ProtocolBase.strftime(datetime.date(1800, 9, 23),
-                     "%Y has the same days as 1980 and 2008")
+                                        "%Y has the same days as 1980 and 2008")
         if s != "1800 has the same days as 1980 and 2008":
             raise AssertionError(s)
 
@@ -672,7 +706,7 @@ class TestPrimitive(unittest.TestCase):
             days.append(datetime.date(2000, 1, i).strftime("%A"))
         nextday = {}
         for i in range(8):
-            nextday[days[i]] = days[i+1]
+            nextday[days[i]] = days[i + 1]
 
         startdate = datetime.date(1, 1, 1)
         enddate = datetime.date(2000, 8, 1)
@@ -682,7 +716,7 @@ class TestPrimitive(unittest.TestCase):
         testdate = startdate + one_day
         while testdate < enddate:
             if (testdate.day == 1 and testdate.month == 1 and
-                (testdate.year % 100 == 0)):
+                                                    (testdate.year % 100 == 0)):
                 print("Testing century", testdate.year)
             day = ProtocolBase.strftime(testdate, "%A")
             if nextday[prevday] != day:
@@ -694,25 +728,31 @@ class TestPrimitive(unittest.TestCase):
         # see the comments on time test for why the rounding here is weird
 
         # rounding 0.1 µsec down
-        dt = ProtocolBase().from_unicode(DateTime, "2015-01-01 12:12:12.0000001")
+        dt = ProtocolBase().from_unicode(DateTime,
+                                                  "2015-01-01 12:12:12.0000001")
         self.assertEquals(datetime.datetime(2015, 1, 1, 12, 12, 12), dt)
 
         # rounding 1.5 µsec up. 0.5 is rounded down by python 3 and up by
         # python 2 so we test with 1.5 µsec instead. frikkin' nonsense.
-        dt = ProtocolBase().from_unicode(DateTime, "2015-01-01 12:12:12.0000015")
+        dt = ProtocolBase().from_unicode(DateTime,
+                                                  "2015-01-01 12:12:12.0000015")
         self.assertEquals(datetime.datetime(2015, 1, 1, 12, 12, 12, 2), dt)
 
         # rounding 999998.8 µsec up
-        dt = ProtocolBase().from_unicode(DateTime, "2015-01-01 12:12:12.9999988")
+        dt = ProtocolBase().from_unicode(DateTime,
+                                                  "2015-01-01 12:12:12.9999988")
         self.assertEquals(datetime.datetime(2015, 1, 1, 12, 12, 12, 999999), dt)
 
         # rounding 999999.1 µsec down
-        dt = ProtocolBase().from_unicode(DateTime, "2015-01-01 12:12:12.9999991")
+        dt = ProtocolBase().from_unicode(DateTime,
+                                                  "2015-01-01 12:12:12.9999991")
         self.assertEquals(datetime.datetime(2015, 1, 1, 12, 12, 12, 999999), dt)
 
         # rounding 999999.8 µsec down, not up.
-        dt = ProtocolBase().from_unicode(DateTime, "2015-01-01 12:12:12.9999998")
+        dt = ProtocolBase().from_unicode(DateTime,
+                                                  "2015-01-01 12:12:12.9999998")
         self.assertEquals(datetime.datetime(2015, 1, 1, 12, 12, 12, 999999), dt)
+
 
 ### Duration Data Type
 ## http://www.w3schools.com/schema/schema_dtypes_date.asp
@@ -731,6 +771,7 @@ class TestPrimitive(unittest.TestCase):
 class SomeBlob(ComplexModel):
     __namespace__ = 'myns'
     howlong = Duration()
+
 
 class TestDurationPrimitive(unittest.TestCase):
     def test_onehour_oneminute_onesecond(self):
@@ -753,7 +794,7 @@ class TestDurationPrimitive(unittest.TestCase):
 
     def test_4suite(self):
         # borrowed from 4Suite
-        tests_seconds =  [
+        tests_seconds = [
             (0, u'PT0S'),
             (1, u'PT1S'),
             (59, u'PT59S'),
@@ -762,8 +803,8 @@ class TestDurationPrimitive(unittest.TestCase):
             (3600, u'PT1H'),
             (86399, u'PT23H59M59S'),
             (86400, u'P1D'),
-            (86400*60, u'P60D'),
-            (86400*400, u'P400D')
+            (86400 * 60, u'P60D'),
+            (86400 * 400, u'P400D')
         ]
 
         for secs, answer in tests_seconds:
@@ -771,7 +812,8 @@ class TestDurationPrimitive(unittest.TestCase):
             gg.howlong = timedelta(seconds=secs)
 
             element = etree.Element('test')
-            XmlDocument().to_parent(None, SomeBlob, gg, element, gg.get_namespace())
+            XmlDocument()\
+                     .to_parent(None, SomeBlob, gg, element, gg.get_namespace())
             element = element[0]
 
             print(gg.howlong)
@@ -791,7 +833,8 @@ class TestDurationPrimitive(unittest.TestCase):
                 gg.howlong = timedelta(seconds=secs)
 
                 element = etree.Element('test')
-                XmlDocument().to_parent(None, SomeBlob, gg, element, gg.get_namespace())
+                XmlDocument()\
+                     .to_parent(None, SomeBlob, gg, element, gg.get_namespace())
                 element = element[0]
 
                 print(gg.howlong)
@@ -868,7 +911,7 @@ class TestDurationPrimitive(unittest.TestCase):
         self.assertEquals(dur, ProtocolBase().from_unicode(Duration, str2))
 
         self.assertEquals(dur, ProtocolBase().from_unicode(Duration,
-                               ProtocolBase().to_unicode(Duration, dur)))
+                                      ProtocolBase().to_unicode(Duration, dur)))
 
 
 if __name__ == '__main__':

--- a/spyne/util/color.py
+++ b/spyne/util/color.py
@@ -51,6 +51,7 @@ except ImportError:
     MAG = lambda s: s
     CYA = lambda s: s
 
+
 if __name__ == '__main__':
     print(R("RED"))
     print(G("GREEN"))

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@
 # python setup.py test
 
 [tox]
-envlist = py27-dj17, py27-dj18, py27-dj19, py27-dj110,
-                     py34-dj18, py34-dj19, py34-dj110,
-                     py35-dj18, py35-dj19, py35-dj110,
+envlist = py27-dj18, py27-dj19, py27-dj110,
+          py34-dj18, py34-dj19, py34-dj110,
+          py35-dj18, py35-dj19, py35-dj110,
+          py36-dj18, py36-dj19, py36-dj110,
 
 usedevelop = True
 
@@ -15,17 +16,6 @@ setenv =
 
 commands =
     py.test --junitxml=test_result.{envname}.xml --cov-append --cov-report= --cov spyne --tb=short {env:TESTS}
-
-[testenv:py27-dj17]
-basepython = {env:BASEPYTHON:python2.7}
-setenv =
-    DJANGO_SETTINGS_MODULE=rpctest.settings
-    PYTHONPATH = {toxinidir}/examples/django/
-    TESTS = spyne/test/interop/test_django.py
-
-deps =
-    Django>=1.7,<18
-    -rrequirements/test_django_req.txt
 
 [testenv:py27-dj18]
 basepython = {env:BASEPYTHON:python2.7}
@@ -60,18 +50,6 @@ deps =
     Django>=1.10,<1.11
     -rrequirements/test_django_req.txt
 
-
-
-[testenv:py34-dj17]
-basepython = {env:BASEPYTHON:python3.4}
-setenv =
-    DJANGO_SETTINGS_MODULE=rpctest.settings
-    PYTHONPATH = {toxinidir}/examples/django/
-    TESTS = spyne/test/interop/test_django.py
-
-deps =
-    Django>=1.7,<1.8
-    -rrequirements/test_django_req.txt
 
 [testenv:py34-dj18]
 basepython = {env:BASEPYTHON:python3.4}
@@ -108,17 +86,6 @@ deps =
 
 
 
-[testenv:py35-dj17]
-basepython = {env:BASEPYTHON:python3.5}
-setenv =
-    DJANGO_SETTINGS_MODULE=rpctest.settings
-    PYTHONPATH = {toxinidir}/examples/django/
-    TESTS = spyne/test/interop/test_django.py
-
-deps =
-    Django>=1.7,<1.8
-    -rrequirements/test_django_req.txt
-
 [testenv:py35-dj18]
 basepython = {env:BASEPYTHON:python3.5}
 setenv =
@@ -143,6 +110,39 @@ deps =
 
 [testenv:py35-dj110]
 basepython = {env:BASEPYTHON:python3.5}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.9,<1.10
+    -rrequirements/test_django_req.txt
+
+[testenv:py36-dj18]
+basepython = {env:BASEPYTHON:python3.6}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.8,<1.9
+    -rrequirements/test_django_req.txt
+
+[testenv:py36-dj19]
+basepython = {env:BASEPYTHON:python3.6}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.8,<1.9
+    -rrequirements/test_django_req.txt
+
+[testenv:py36-dj110]
+basepython = {env:BASEPYTHON:python3.6}
 setenv =
     DJANGO_SETTINGS_MODULE=rpctest.settings
     PYTHONPATH = {toxinidir}/examples/django/


### PR DESCRIPTION
As the selection of namespaces was divided between `spyne.const.xml_ns` and `spyne.cons.xml`, the resulting WSDL and XSD files when working on Soap12 where incorrect.
I migrated all uses op `xml_ns` to `xml` so the addition of Soap12 will be easier to make.

This also makes slight changes to the `.travis.yml` file, it now uses the matrix to select between testsuites.