### PR TITLE
This replaces any use of the deprecated `spyne.const.xml_ns` with `spyne.const.xml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  # disable pypy -- travis' pypy deployment seems broken
-  # - "pypy"
-before_install:
-  #- sudo apt-get update
-  #- sudo apt-get install -qq libzmq-dev
+matrix:
+  include:
+  - python: "2.7"
+    env: TEST_SUITE=test
+  - python: "3.4"
+    env: TEST_SUITE=test_python3
+  - python: "3.5"
+    env: TEST_SUITE=test_python3
 install:
-  - pip install tox
-script:
   - pip install -r requirements/test_requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then  python setup.py test; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then  python setup.py test_python3; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then  python setup.py test_python3; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pypi setup.py test; fi
+script:
+  - python setup.py $TEST_SUITE
+  

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ spyne-2.13.0
   ``spyne.BODY_STYLE_EMPTY`` before. This hould not break anything unless you
   are doing some REAL fancy stuff in the method decorators or service events.
 * Auxproc is DEPRECATED. Just get rid of it.
+* `spyne.const.xml_ns` is deprecated. Replaced uses by `spyne.const.xml`.
 * `spyne.protocol.dictdoc.simple`, `spyne.server.twisted.http` and
   `spyne.server.django` are not experimental anymore.
 * No major changes otherwise but we paid a lot of technical debt. e.g. We

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=2.9
 pytest-twisted
 pytest-cov
 coverage

--- a/spyne/const/xml.py
+++ b/spyne/const/xml.py
@@ -35,6 +35,7 @@ NS_SOAP12_ENV = 'http://www.w3.org/2003/05/soap-envelope'
 
 NS_WSDL11 = 'http://schemas.xmlsoap.org/wsdl/'
 NS_WSDL11_SOAP = 'http://schemas.xmlsoap.org/wsdl/soap/'
+NS_WSDL12_SOAP = 'http://schemas.xmlsoap.org/wsdl/soap12/'
 
 NSMAP = {
     'xml': NS_XML,
@@ -42,6 +43,7 @@ NSMAP = {
     'xsi': NS_XSI,
     'plink': NS_PLINK,
     'wsdlsoap11': NS_WSDL11_SOAP,
+    'wsdlsoap12': NS_WSDL12_SOAP,
     'wsdl': NS_WSDL11,
     'soap11enc': NS_SOAP11_ENC,
     'soap11env': NS_SOAP11_ENV,
@@ -82,6 +84,7 @@ SOAP12_ENC = Tnswrap(NS_SOAP12_ENC)
 SOAP12_ENV = Tnswrap(NS_SOAP12_ENV)
 WSDL11 = Tnswrap(NS_WSDL11)
 WSDL11_SOAP = Tnswrap(NS_WSDL11_SOAP)
+WSDL12_SOAP = Tnswrap(NS_WSDL12_SOAP)
 
 
 # names starting with underscore need () around to be used as proper regexps

--- a/spyne/const/xml_ns.py
+++ b/spyne/const/xml_ns.py
@@ -19,7 +19,6 @@
 
 # This module is DEPRECATED. Use ``spyne.const.xml``.
 
-# FIXME: These are constants, so should have been all UPPERCASE.
 xml = 'http://www.w3.org/XML/1998/namespace'
 xsd = 'http://www.w3.org/2001/XMLSchema'
 xsi = 'http://www.w3.org/2001/XMLSchema-instance'

--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -26,7 +26,7 @@ to have a more elegant way of passing frequently-used parameter values. The @rpc
 decorator is a simple example of this.
 """
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from copy import copy
 from inspect import isclass
@@ -84,7 +84,7 @@ def _produce_input_message(f, params, in_message_name,
         k = in_variable_names.get(k, k)
         in_params[k] = v
 
-    ns = spyne.const.xml_ns.DEFAULT_NS
+    ns = spyne.const.xml.DEFAULT_NS
     if in_message_name.startswith("{"):
         ns, _, in_message_name = in_message_name[1:].partition("}")
 
@@ -179,7 +179,7 @@ def _produce_output_message(func_name, body_style_str, kparams):
 
             out_params[_out_variable_name] = _returns
 
-    ns = spyne.const.xml_ns.DEFAULT_NS
+    ns = spyne.const.xml.DEFAULT_NS
     if _out_message_name.startswith("{"):
         ns = _out_message_name[1:].partition("}")[0]
 

--- a/spyne/descriptor.py
+++ b/spyne/descriptor.py
@@ -20,7 +20,7 @@
 import logging
 logger = logging.getLogger('spyne')
 
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 
 from spyne.util import six
 

--- a/spyne/interface/_base.py
+++ b/spyne/interface/_base.py
@@ -28,7 +28,7 @@ from spyne import EventManager, MethodDescriptor
 from spyne.util import six
 from spyne.model import ModelBase, Array, Iterable, ComplexModelBase
 from spyne.model.complex import XmlModifier
-from spyne.const import xml_ns as namespace
+from spyne.const import xml as namespace
 
 
 class Interface(object):
@@ -79,8 +79,8 @@ class Interface(object):
         self.imports = {self.get_tns(): set()}
         self.service_method_map = {}
         self.method_id_map = {}
-        self.nsmap = dict(namespace.const_nsmap)
-        self.prefmap = dict(namespace.const_prefmap)
+        self.nsmap = dict(namespace.NSMAP)
+        self.prefmap = dict(namespace.PREFMAP)
         self.member_methods = deque()
 
         self.nsmap['tns'] = self.get_tns()
@@ -485,7 +485,7 @@ class Interface(object):
         if ns is None:
             raise ValueError(ns)
 
-        return self.import_base_namespaces or not (ns in namespace.const_prefmap)
+        return self.import_base_namespaces or not (ns in namespace.PREFMAP)
 
 
 class AllYourInterfaceDocuments(object):

--- a/spyne/interface/wsdl/defn.py
+++ b/spyne/interface/wsdl/defn.py
@@ -1,7 +1,7 @@
 
 from spyne.util.six import add_metaclass
 
-from spyne.const import xml_ns
+from spyne.const import xml
 
 from spyne.model.primitive import Unicode
 from spyne.model.complex import XmlAttribute
@@ -12,12 +12,12 @@ from spyne.interface.xml_schema.defn import XmlSchema10
 
 @add_metaclass(ComplexModelMeta)
 class Wsdl11Base(ComplexModelBase):
-    __namespace__ = xml_ns.wsdl
+    __namespace__ = xml.NS_WSDL11
 
 
 @add_metaclass(ComplexModelMeta)
 class Soap11Base(ComplexModelBase):
-    __namespace__ = xml_ns.soap
+    __namespace__ = xml.NS_WSDL11_SOAP
 
 
 class Types(Wsdl11Base):
@@ -47,9 +47,9 @@ class SoapHeaderDefinition(Wsdl11Base):
 class OperationMode(Wsdl11Base):
     name = XmlAttribute(Unicode)
     message = XmlAttribute(Unicode)
-    soap_body = SoapBodyDefinition.customize(sub_ns=xml_ns.soap,
+    soap_body = SoapBodyDefinition.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                               sub_name="body")
-    soap_header = SoapHeaderDefinition.customize(sub_ns=xml_ns.soap,
+    soap_header = SoapHeaderDefinition.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                               sub_name="header")
 
 
@@ -61,7 +61,7 @@ class SoapOperation(Wsdl11Base):
 class Operation(Wsdl11Base):
     input = OperationMode
     output = OperationMode
-    soap_operation = SoapOperation.customize(sub_ns=xml_ns.soap,
+    soap_operation = SoapOperation.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                              sub_name="operation")
     parameterOrder = XmlAttribute(Unicode)
 
@@ -79,7 +79,7 @@ class Binding(Wsdl11Base):
     name = XmlAttribute(Unicode)
     type = XmlAttribute(Unicode)
     location = XmlAttribute(Unicode)
-    soap_binding = SoapBinding.customize(sub_ns=xml_ns.soap,
+    soap_binding = SoapBinding.customize(sub_ns=xml.NS_WSDL11_SOAP,
                                                            sub_name="binding")
 
 
@@ -90,7 +90,7 @@ class PortAddress(Soap11Base):
 class ServicePort(Wsdl11Base):
     name = XmlAttribute(Unicode)
     binding = XmlAttribute(Unicode)
-    address = PortAddress.customize(sub_ns=xml_ns.soap)
+    address = PortAddress.customize(sub_ns=xml.NS_WSDL11_SOAP)
 
 
 class Service(Wsdl11Base):

--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 import re
 REGEX_WSDL = re.compile('[.?]wsdl$')
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from lxml import etree
 from lxml.builder import E

--- a/spyne/interface/xml_schema/_base.py
+++ b/spyne/interface/xml_schema/_base.py
@@ -24,7 +24,7 @@ import os
 import shutil
 import tempfile
 
-import spyne.const.xml_ns
+import spyne.const.xml as ns
 
 from lxml import etree
 from itertools import chain
@@ -68,11 +68,11 @@ _get_restriction_tag_handlers = cdict({
     Date: Tget_range_restriction_tag(Date),
 })
 
-_ns_xsd = spyne.const.xml_ns.xsd
-_ns_wsa = spyne.const.xml_ns.wsa
-_ns_wsdl = spyne.const.xml_ns.wsdl
-_ns_soap = spyne.const.xml_ns.soap
-_pref_wsa = spyne.const.xml_ns.const_prefmap[_ns_wsa]
+_ns_xsd = ns.NS_XSD
+_ns_wsa = ns.NS_WSA
+_ns_wsdl = ns.NS_WSDL11
+_ns_soap = ns.NS_WSDL11_SOAP
+_pref_wsa = ns.PREFMAP[_ns_wsa]
 
 
 class SchemaInfo(object):
@@ -137,7 +137,7 @@ class XmlSchema(InterfaceDocumentBase):
 
             # append import tags
             for namespace in self.interface.imports[self.interface.nsmap[pref]]:
-                import_ = etree.SubElement(schema, "{%s}import" % _ns_xsd)
+                import_ = etree.SubElement(schema, ns.XSD('import'))
 
                 import_.set("namespace", namespace)
                 import_pref = self.interface.get_namespace_prefix(namespace)
@@ -145,7 +145,7 @@ class XmlSchema(InterfaceDocumentBase):
                                         self.namespaces.get(import_pref, False):
                     import_.set('schemaLocation', "%s.xsd" % import_pref)
 
-                sl = spyne.const.xml_ns.schema_location.get(namespace, None)
+                sl = ns.schema_location.get(namespace, None)
                 if not (sl is None):
                     import_.set('schemaLocation', sl)
 
@@ -179,7 +179,7 @@ class XmlSchema(InterfaceDocumentBase):
                 name = method.in_message.get_type_name()
 
             if not name in elements:
-                element = etree.Element('{%s}element' % _ns_xsd)
+                element = etree.Element(ns.XSD('element'))
                 element.set('name', name)
                 element.set('type', method.in_message.get_type_name_ns(
                                                                 self.interface))
@@ -191,7 +191,7 @@ class XmlSchema(InterfaceDocumentBase):
                 if name is None:
                     name = method.out_message.get_type_name()
                 if not name in elements:
-                    element = etree.Element('{%s}element' % _ns_xsd)
+                    element = etree.Element(ns.XSD('element'))
                     element.set('name', name)
                     element.set('type', method.out_message \
                                               .get_type_name_ns(self.interface))
@@ -242,7 +242,7 @@ class XmlSchema(InterfaceDocumentBase):
         """Return schema node for the given namespace prefix."""
 
         if not (pref in self.schema_dict):
-            schema = etree.Element("{%s}schema" % _ns_xsd,
+            schema = etree.Element(ns.XSD('schema'),
                                                      nsmap=self.interface.nsmap)
 
             schema.set("targetNamespace", self.interface.nsmap[pref])

--- a/spyne/interface/xml_schema/defn.py
+++ b/spyne/interface/xml_schema/defn.py
@@ -19,7 +19,7 @@
 
 from spyne.util.six import add_metaclass
 
-from spyne.const import xml_ns
+from spyne.const import xml
 from spyne.model.primitive import Boolean, AnyHtml
 from spyne.model.primitive import Unicode
 from spyne.model.primitive import UnsignedInteger
@@ -30,7 +30,7 @@ from spyne.model.complex import ComplexModelMeta
 
 @add_metaclass(ComplexModelMeta)
 class SchemaBase(ComplexModelBase):
-    __namespace__ = xml_ns.xsd
+    __namespace__ = xml.NS_XSD
 
 
 class Import(SchemaBase):

--- a/spyne/interface/xml_schema/model.py
+++ b/spyne/interface/xml_schema/model.py
@@ -31,15 +31,13 @@ from lxml import etree
 
 from spyne.model import ModelBase, XmlAttribute, AnyXml, Unicode, XmlData, \
     Decimal, Integer
-from spyne.const.xml_ns import xsd as _ns_xsd
+from spyne.const.xml import NS_XSD, XSD
 from spyne.util import memoize
 from spyne.util.cdict import cdict
 from spyne.util.etreeconv import dict_to_etree
 from spyne.util.six import string_types
 from spyne.protocol.xml import XmlDocument
 _prot = XmlDocument()
-
-XSD = lambda s: '{%s}%s' % (_ns_xsd, s)
 
 # In Xml Schema, some customizations do not need a class to be extended -- they
 # are specified in-line in the parent class definition, like nullable or
@@ -292,7 +290,7 @@ def enum_add(document, cls, tags):
 
     restriction = etree.SubElement(simple_type, XSD('restriction'))
     restriction.set('base', '%s:string' %
-                               document.interface.get_namespace_prefix(_ns_xsd))
+                               document.interface.get_namespace_prefix(NS_XSD))
 
     for v in cls.__values__:
         enumeration = etree.SubElement(restriction, XSD('enumeration'))

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -30,7 +30,7 @@ import re
 import decimal
 import threading
 
-import spyne.const.xml_ns
+import spyne.const.xml
 
 from collections import OrderedDict
 
@@ -39,7 +39,7 @@ from spyne.util import Break, six
 from spyne.util.cdict import cdict
 from spyne.util.odict import odict
 
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 
 
 def _decode_pa_dict(d):
@@ -270,7 +270,7 @@ class ModelBase(object):
         will imply an iterable of objects as native python type. Can be set to
         ``decimal.Decimal("inf")`` for arbitrary number of arguments."""
 
-        schema_tag = '{%s}element' % spyne.const.xml_ns.xsd
+        schema_tag = spyne.const.xml.XSD('element')
         """The tag used to add a primitives as child to a complex type in the
         xml schema."""
 
@@ -482,10 +482,10 @@ class ModelBase(object):
             return False
         tags.add(cls)
 
-        if cls.__namespace__ is spyne.const.xml_ns.DEFAULT_NS:
+        if cls.__namespace__ is spyne.const.xml.DEFAULT_NS:
             cls.__namespace__ = default_ns
 
-        if (cls.__namespace__ in spyne.const.xml_ns.const_prefmap and
+        if (cls.__namespace__ in spyne.const.xml.PREFMAP and
                                                        not cls.is_default(cls)):
             cls.__namespace__ = default_ns
 

--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -39,7 +39,7 @@ from itertools import chain
 from spyne import BODY_STYLE_BARE, BODY_STYLE_WRAPPED, EventManager
 
 from spyne import const
-from spyne.const import xml_ns
+from spyne.const.xml import PREFMAP
 
 from spyne.model import Point, Unicode, PushBase, ModelBase
 from spyne.model import json, xml, msgpack, table
@@ -123,7 +123,7 @@ class XmlModifier(ModelBase):
         if cls.__namespace__ is None:
             cls.__namespace__ = cls.type.get_namespace()
 
-        if cls.__namespace__ in xml_ns.const_prefmap:
+        if cls.__namespace__ in PREFMAP:
             cls.__namespace__ = default_ns
 
     @classmethod
@@ -1442,7 +1442,7 @@ class Array(ComplexModelBase):
         if cls.__namespace__ is None:
             cls.__namespace__ = serializer.get_namespace()
 
-        if cls.__namespace__ in xml_ns.const_prefmap:
+        if cls.__namespace__ in PREFMAP:
             cls.__namespace__ = default_ns
 
         return ComplexModel.resolve_namespace(cls, default_ns, tags)

--- a/spyne/protocol/cloth/to_parent.py
+++ b/spyne/protocol/cloth/to_parent.py
@@ -28,7 +28,7 @@ from collections import Iterable
 from lxml import etree, html
 from lxml.builder import E
 
-from spyne.const.xml_ns import xsi as NS_XSI, soap11_env as NS_SOAP_ENV
+from spyne.const.xml import NS_XSI, NS_SOAP11_ENV, SOAP11_ENV
 from spyne.model import PushBase, ComplexModelBase, AnyXml, Fault, AnyDict, \
     AnyHtml, ModelBase, ByteArray, XmlData, Any, AnyUri, ImageUri, XmlAttribute
 
@@ -475,8 +475,8 @@ class ToParentMixin(OutProtocolBase):
                         pass
 
     def fault_to_parent(self, ctx, cls, inst, parent, name):
-        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP_ENV]
-        tag_name = "{%s}Fault" % NS_SOAP_ENV
+        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP11_ENV]
+        tag_name = SOAP11_ENV("Fault")
 
         with parent.element(tag_name):
             parent.write(
@@ -494,8 +494,8 @@ class ToParentMixin(OutProtocolBase):
             # PushBase instance here.
 
     def schema_validation_error_to_parent(self, ctx, cls, inst, parent, **_):
-        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP_ENV]
-        tag_name = "{%s}Fault" % NS_SOAP_ENV
+        PREF_SOAP_ENV = ctx.app.interface.prefmap[NS_SOAP11_ENV]
+        tag_name = SOAP11_ENV("Fault")
 
         with parent.element(tag_name):
             parent.write(

--- a/spyne/protocol/soap/mime.py
+++ b/spyne/protocol/soap/mime.py
@@ -42,9 +42,9 @@ from email import message_from_string
 from spyne.model.binary import Attachment
 from spyne.model.binary import ByteArray
 
-import spyne.const.xml_ns
-_ns_xop = spyne.const.xml_ns.xop
-_ns_soap_env = spyne.const.xml_ns.soap11_env
+import spyne.const.xml
+_ns_xop = spyne.const.xml.NS_XOP
+_ns_soap_env = spyne.const.xml.NS_SOAP11_ENV
 
 from spyne.util.six.moves.urllib.parse import unquote
 

--- a/spyne/protocol/soap/soap11.py
+++ b/spyne/protocol/soap/soap11.py
@@ -42,7 +42,7 @@ import cgi
 
 from itertools import chain
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 from lxml import etree
 from lxml.etree import XMLSyntaxError
@@ -50,7 +50,7 @@ from lxml.etree import XMLParser
 
 from spyne import BODY_STYLE_WRAPPED
 from spyne.util import six
-from spyne.const.xml_ns import DEFAULT_NS
+from spyne.const.xml import DEFAULT_NS
 from spyne.const.http import HTTP_405, HTTP_500
 from spyne.error import RequestNotAllowed
 from spyne.model.fault import Fault
@@ -63,7 +63,7 @@ from spyne.server.http import HttpTransportContext
 def _from_soap(in_envelope_xml, xmlids=None, **kwargs):
     """Parses the xml string into the header and payload.
     """
-    ns_soap = kwargs.pop('ns', ns.soap11_env)
+    ns_soap = kwargs.pop('ns', ns.NS_SOAP11_ENV)
 
     if xmlids:
         resolve_hrefs(in_envelope_xml, xmlids)

--- a/spyne/protocol/xml.py
+++ b/spyne/protocol/xml.py
@@ -57,9 +57,8 @@ from spyne.error import ValidationError
 from spyne.const.ansi_color import LIGHT_GREEN
 from spyne.const.ansi_color import LIGHT_RED
 from spyne.const.ansi_color import END_COLOR
-from spyne.const.xml_ns import xsi as _ns_xsi
-from spyne.const.xml_ns import soap11_env
-from spyne.const.xml_ns import const_prefmap, DEFAULT_NS
+from spyne.const.xml import NS_SOAP11_ENV
+from spyne.const.xml import PREFMAP, DEFAULT_NS
 
 from spyne.model import Any
 from spyne.model import ModelBase
@@ -232,8 +231,8 @@ class XmlDocument(SubXmlBase):
     type = set(ProtocolBase.type)
     type.add('xml')
 
-    soap_env = const_prefmap[soap11_env]
-    ns_soap_env = soap11_env
+    soap_env = PREFMAP[NS_SOAP11_ENV]
+    ns_soap_env = NS_SOAP11_ENV
 
     def __init__(self, app=None, validator=None,
                 replace_null_with_default=True,
@@ -407,7 +406,7 @@ class XmlDocument(SubXmlBase):
         self.validate_body(ctx, message)
 
     def from_element(self, ctx, cls, element):
-        if bool(element.get('{%s}nil' % _ns_xsi)):
+        if bool(element.get(XSI('nil'))):
             if self.validator is self.SOFT_VALIDATION and not \
                                                         cls.Attributes.nillable:
                 raise ValidationError('')

--- a/spyne/test/interface/test_wsgi.py
+++ b/spyne/test/interface/test_wsgi.py
@@ -27,7 +27,7 @@ from spyne.server.wsgi import WsgiApplication
 from spyne.application import Application
 from spyne.model.primitive import Unicode
 from spyne.decorator import rpc
-from spyne.const.xml_ns import wsdl as NS_WSDL
+from spyne.const.xml import WSDL11
 from spyne.service import ServiceBase
 
 
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
 
         from lxml import etree
 
-        assert etree.fromstring(retval).tag == '{%s}definitions' % NS_WSDL
+        assert etree.fromstring(retval).tag == WSDL11('definitions')
 
 if __name__ == '__main__':
     unittest.main()

--- a/spyne/test/interface/test_xml_schema.py
+++ b/spyne/test/interface/test_xml_schema.py
@@ -25,7 +25,7 @@ from lxml import etree
 
 from spyne import Application
 from spyne import rpc
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 from spyne.const.xml import NS_XSD
 from spyne.model import ByteArray
 from spyne.model import ComplexModel
@@ -72,10 +72,10 @@ class TestXmlSchema(unittest.TestCase):
         print(etree.tostring(doc, pretty_print=True))
         assert len(doc.xpath('/xs:schema/xs:complexType[@name="SomeObject"]'
                                    '/xs:sequence/xs:element[@name="punk"]',
-            namespaces={'xs': ns.xsd})) > 0
+            namespaces={'xs': NS_XSD})) > 0
         assert len(doc.xpath('/xs:schema/xs:complexType[@name="SomeObject"]'
                     '/xs:sequence/xs:choice/xs:element[@name="one"]',
-            namespaces={'xs': ns.xsd})) > 0
+            namespaces={'xs': NS_XSD})) > 0
 
     def test_customized_class_with_empty_subclass(self):
         class SummaryStatsOfDouble(ComplexModel):
@@ -178,8 +178,8 @@ class TestXmlSchema(unittest.TestCase):
             out_protocol=Soap11()
         )
 
-        _ns = {'xs': ns.xsd}
-        pref_xs = ns.const_prefmap[ns.xsd]
+        _ns = {'xs': NS_XSD}
+        pref_xs = ns.PREFMAP[NS_XSD]
         xs = XmlSchema(app.interface)
         xs.build_interface_document()
         elt = xs.get_interface_document()['tns'].xpath(
@@ -216,16 +216,16 @@ class TestXmlSchema(unittest.TestCase):
         class SomeType(ComplexModel):
             __namespace__ = "zo"
 
-            anything = AnyXml(schema_tag='{%s}any' % ns.xsd, namespace='##other',
+            anything = AnyXml(schema_tag='{%s}any' % NS_XSD, namespace='##other',
                                                          process_contents='lax')
 
         docs = get_schema_documents([SomeType])
         print(etree.tostring(docs['tns'], pretty_print=True))
-        any = docs['tns'].xpath('//xsd:any', namespaces={'xsd': ns.xsd})
+        _any = docs['tns'].xpath('//xsd:any', namespaces={'xsd': NS_XSD})
 
-        assert len(any) == 1
-        assert any[0].attrib['namespace'] == '##other'
-        assert any[0].attrib['processContents'] == 'lax'
+        assert len(_any) == 1
+        assert _any[0].attrib['namespace'] == '##other'
+        assert _any[0].attrib['processContents'] == 'lax'
 
     def _build_xml_data_test_schema(self, custom_root):
         tns = 'kickass.ns'
@@ -268,7 +268,7 @@ class TestXmlSchema(unittest.TestCase):
         assert len(schema.get_interface_document()['tns'].xpath(
                 '/xs:schema/xs:complexType[@name="ProductEdition"]'
                 '/xs:simpleContent/xs:extension/xs:attribute[@name="id"]'
-                ,namespaces={'xs': ns.xsd})) == 1
+                ,namespaces={'xs': NS_XSD})) == 1
 
     def _test_xml_data_validation(self):
         schema = self._build_xml_data_test_schema(custom_root=False)
@@ -294,7 +294,7 @@ class TestXmlSchema(unittest.TestCase):
     def test_subs(self):
         from lxml import etree
         from spyne.util.xml import get_schema_documents
-        xpath = lambda o, x: o.xpath(x, namespaces={"xs": ns.xsd})
+        xpath = lambda o, x: o.xpath(x, namespaces={"xs": NS_XSD})
 
         m = {
             "s0": "aa",
@@ -325,7 +325,7 @@ class TestXmlSchema(unittest.TestCase):
         #assert len(xpath(seq, 'xs:element[@name="{dd}dd"]')) == 1
 
     def test_mandatory(self):
-        xpath = lambda o, x: o.xpath(x, namespaces={"xs": ns.xsd})
+        xpath = lambda o, x: o.xpath(x, namespaces={"xs": NS_XSD})
 
         class C(ComplexModel):
             __namespace__ = "aa"

--- a/spyne/test/interface/wsdl/__init__.py
+++ b/spyne/test/interface/wsdl/__init__.py
@@ -20,7 +20,7 @@
 from spyne.application import Application
 from spyne.interface.wsdl import Wsdl11
 from spyne.protocol.soap import Soap11
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 def build_app(service_list, tns, name):
     app = Application(service_list, tns, name=name,
@@ -32,12 +32,12 @@ class AppTestWrapper():
     def __init__(self, application):
 
         self.url = 'http:/localhost:7789/wsdl'
-        self.service_string = '{%s}service' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
-        self.soap_binding_string = '{%s}binding' % ns.soap
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
+        self.service_string = ns.WSDL11('service')
+        self.port_string = ns.WSDL11('port')
+        self.soap_binding_string = ns.WSDL11_SOAP('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_type_string = ns.WSDL11('portType')
+        self.binding_string = ns.WSDL11('binding')
 
         self.app = application
         self.interface_doc = Wsdl11(self.app.interface)

--- a/spyne/test/interface/wsdl/test_bindings.py
+++ b/spyne/test/interface/wsdl/test_bindings.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 import unittest
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 
 from spyne.interface.wsdl.wsdl11 import Wsdl11
@@ -36,11 +36,11 @@ class TestWSDLBindingBehavior(unittest.TestCase):
     def setUp(self):
         self.transport = 'http://schemas.xmlsoap.org/soap/http'
         self.url = 'http:/localhost:7789/wsdl'
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.service_string = '{%s}service' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
+        self.port_type_string = ns.WSDL11('portType')
+        self.service_string = ns.WSDL11('service')
+        self.binding_string = ns.WSDL11('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_string = ns.WSDL11('port')
 
     def test_binding_simple(self):
         sa = build_app([TS1()], 'S1Port', 'TestServiceName')

--- a/spyne/test/interface/wsdl/test_default_wsdl.py
+++ b/spyne/test/interface/wsdl/test_default_wsdl.py
@@ -36,7 +36,7 @@ from spyne.const import REQUEST_SUFFIX
 from spyne.const import RESPONSE_SUFFIX
 from spyne.const import ARRAY_SUFFIX
 
-from spyne.const.xml_ns import const_nsmap
+from spyne.const.xml import NSMAP
 from spyne.decorator import srpc
 from spyne.service import ServiceBase
 from spyne.interface.wsdl import Wsdl11

--- a/spyne/test/interface/wsdl/test_op_req_suffix.py
+++ b/spyne/test/interface/wsdl/test_op_req_suffix.py
@@ -30,6 +30,7 @@ from spyne.protocol.http import HttpRpc
 from spyne.protocol.json import JsonDocument
 from spyne.server.wsgi import WsgiApplication
 
+from spyne.const.xml import PREFMAP, NS_WSDL11_SOAP
 
 def strip_whitespace(string):
     return ''.join(string.split())
@@ -162,7 +163,7 @@ class TestOperationRequestSuffix(unittest.TestCase):
 
         soap_strings = [
             '<wsdl:operation name="{0}"'.format(operation_name),
-            '<soap:operation soapAction="{0}"'.format(operation_name),
+            '<{0}:operation soapAction="{1}"'.format(PREFMAP[NS_WSDL11_SOAP], operation_name),
             '<wsdl:input name="{0}">'.format(request_name),
             '<xs:element name="{0}"'.format(request_name),
             '<xs:complexType name="{0}">'.format(request_name),

--- a/spyne/test/interface/wsdl/test_wsdl_ports_services.py
+++ b/spyne/test/interface/wsdl/test_wsdl_ports_services.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 import unittest
 
-import spyne.const.xml_ns as ns
+import spyne.const.xml as ns
 
 from spyne.test.interface.wsdl import AppTestWrapper
 from spyne.test.interface.wsdl import build_app
@@ -37,11 +37,11 @@ class TestWSDLPortServiceBehavior(unittest.TestCase):
     def setUp(self):
         self.transport = 'http://schemas.xmlsoap.org/soap/http'
         self.url = 'http:/localhost:7789/wsdl'
-        self.port_type_string = '{%s}portType' % ns.wsdl
-        self.service_string = '{%s}service' % ns.wsdl
-        self.binding_string = '{%s}binding' % ns.wsdl
-        self.operation_string = '{%s}operation' % ns.wsdl
-        self.port_string = '{%s}port' % ns.wsdl
+        self.port_type_string = ns.WSDL11('portType')
+        self.service_string = ns.WSDL11('service')
+        self.binding_string = ns.WSDL11('binding')
+        self.operation_string = ns.WSDL11('operation')
+        self.port_string = ns.WSDL11('port')
 
     def test_tns(self):
         sa = build_app([TSinglePortService()], 'SinglePort', 'TestServiceName')

--- a/spyne/test/model/test_binary.py
+++ b/spyne/test/model/test_binary.py
@@ -23,9 +23,9 @@ from lxml import etree
 from spyne.protocol.soap import Soap11
 from spyne.model.binary import ByteArray
 from spyne.model.binary import _bytes_join
-import spyne.const.xml_ns
+import spyne.const.xml
 
-ns_xsd = spyne.const.xml_ns.xsd
+ns_xsd = spyne.const.xml.NS_XSD
 ns_test = 'test_namespace'
 
 

--- a/spyne/test/model/test_complex.py
+++ b/spyne/test/model/test_complex.py
@@ -33,7 +33,7 @@ from decimal import Decimal as D
 from spyne import Application, rpc, mrpc, ServiceBase, ByteArray, Array, \
     ComplexModel, SelfReference, XmlData, XmlAttribute, Unicode, DateTime, \
     Float, Integer, String
-from spyne.const import xml_ns
+from spyne.const import xml
 from spyne.error import ResourceNotFoundError
 from spyne.interface import Interface
 from spyne.interface.wsdl import Wsdl11
@@ -409,7 +409,7 @@ class TestXmlAttribute(unittest.TestCase):
         wsdl.build_interface_document('http://a-aaaa.com')
         pref = CM.get_namespace_prefix(interface)
         type_def = wsdl.get_schema_info(pref).types[CM.get_type_name()]
-        attribute_def = type_def.find('{%s}attribute' % xml_ns.xsd)
+        attribute_def = type_def.find(xml.XSD('attribute'))
         print(etree.tostring(type_def, pretty_print=True))
 
         self.assertIsNotNone(attribute_def)

--- a/spyne/test/model/test_enum.py
+++ b/spyne/test/model/test_enum.py
@@ -22,7 +22,7 @@ import unittest
 from pprint import pprint
 
 from spyne.application import Application
-from spyne.const.xml_ns import xsd as _ns_xsd
+from spyne.const.xml import XSD
 from spyne.interface.wsdl.wsdl11 import Wsdl11
 from spyne.model.complex import Array
 from spyne.model.complex import ComplexModel
@@ -88,7 +88,7 @@ class TestEnum(unittest.TestCase):
         print(simple_type)
 
         self.assertEquals(simple_type.attrib['name'], 'DaysOfWeekEnum')
-        self.assertEquals(simple_type[0].tag, "{%s}restriction" % _ns_xsd)
+        self.assertEquals(simple_type[0].tag, XSD("restriction"))
         self.assertEquals([e.attrib['value'] for e in simple_type[0]], vals)
 
     def test_serialize(self):

--- a/spyne/test/model/test_exception.py
+++ b/spyne/test/model/test_exception.py
@@ -53,9 +53,9 @@ class FaultTests(unittest.TestCase):
 
     def test_to_parent_wo_detail(self):
         from lxml.etree import Element
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
-        soap_env = spyne.const.xml_ns.const_prefmap[spyne.const.xml_ns.soap11_env]
+        import spyne.const.xml
+        ns_soap_env = spyne.const.xml.NS_SOAP11_ENV
+        soap_env = spyne.const.xml.PREFMAP[spyne.const.xml.NS_SOAP11_ENV]
 
         element = Element('testing')
         fault = Fault()
@@ -85,10 +85,10 @@ class FaultTests(unittest.TestCase):
     def test_from_xml_wo_detail(self):
         from lxml.etree import Element
         from lxml.etree import SubElement
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
-        soap_env = spyne.const.xml_ns.const_prefmap[spyne.const.xml_ns.soap11_env]
-        element = Element('{%s}Fault' % ns_soap_env)
+        from spyne.const.xml import PREFMAP, SOAP11_ENV, NS_SOAP11_ENV
+
+        soap_env = PREFMAP[NS_SOAP11_ENV]
+        element = Element(SOAP11_ENV('Fault'))
 
         fcode = SubElement(element, 'faultcode')
         fcode.text = '%s:other' % soap_env
@@ -107,10 +107,9 @@ class FaultTests(unittest.TestCase):
     def test_from_xml_w_detail(self):
         from lxml.etree import Element
         from lxml.etree import SubElement
-        import spyne.const.xml_ns
-        ns_soap_env = spyne.const.xml_ns.soap11_env
+        from spyne.const.xml import SOAP11_ENV
 
-        element = Element('{%s}Fault' % ns_soap_env)
+        element = Element(SOAP11_ENV('Fault'))
         fcode = SubElement(element, 'faultcode')
         fcode.text = 'soap11env:other'
         fstr = SubElement(element, 'faultstring')
@@ -124,8 +123,7 @@ class FaultTests(unittest.TestCase):
         self.failUnless(fault.detail is detail)
 
     def test_add_to_schema_no_extends(self):
-        import spyne.const.xml_ns
-        ns_xsd = spyne.const.xml_ns.xsd
+        from spyne.const.xml import XSD
 
         class cls(Fault):
             __namespace__='ns'
@@ -145,19 +143,18 @@ class FaultTests(unittest.TestCase):
         c_cls = interface.classes['{ns}cls']
         c_elt = schema.types[0]
         self.failUnless(c_cls is cls)
-        self.assertEqual(c_elt.tag, '{%s}complexType' % ns_xsd)
+        self.assertEqual(c_elt.tag, XSD('complexType'))
         self.assertEqual(c_elt.get('name'), 'cls')
 
         self.assertEqual(len(schema.elements), 1)
         e_elt = schema.elements.values()[0]
-        self.assertEqual(e_elt.tag, '{%s}element' % ns_xsd)
+        self.assertEqual(e_elt.tag, XSD('element'))
         self.assertEqual(e_elt.get('name'), 'cls')
         self.assertEqual(e_elt.get('type'), 'testing:My')
         self.assertEqual(len(e_elt), 0)
 
     def test_add_to_schema_w_extends(self):
-        import spyne.const.xml_ns
-        ns_xsd = spyne.const.xml_ns.xsd
+        from spyne.const.xml import XSD
 
         class base(Fault):
             __namespace__ = 'ns'
@@ -185,7 +182,7 @@ class FaultTests(unittest.TestCase):
         c_elt = next(iter(schema.types.values()))
 
         self.failUnless(c_cls is cls)
-        self.assertEqual(c_elt.tag, '{%s}complexType' % ns_xsd)
+        self.assertEqual(c_elt.tag, XSD('complexType'))
         self.assertEqual(c_elt.get('name'), 'cls')
 
         from lxml import etree

--- a/spyne/test/model/test_include.py
+++ b/spyne/test/model/test_include.py
@@ -30,7 +30,7 @@ from spyne.model.primitive import Integer
 from spyne.model.primitive import String
 from spyne.protocol.xml import XmlDocument
 from spyne.protocol.soap.mime import _join_attachment
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 
 # Service Classes
 class DownloadPartFileResult(ComplexModel):
@@ -64,7 +64,7 @@ class TestInclude(unittest.TestCase):
 
         soaptree = etree.fromstring(joinedmsg)
 
-        body = soaptree.find("{%s}Body" % ns.soap11_env)
+        body = soaptree.find(ns.SOAP11_ENV("Body"))
         response = body.getchildren()[0]
         result = response.getchildren()[0]
         r = XmlDocument().from_element(None, DownloadPartFileResult, result)

--- a/spyne/test/model/test_primitive.py
+++ b/spyne/test/model/test_primitive.py
@@ -33,7 +33,7 @@ from datetime import timedelta
 from lxml import etree
 
 from spyne.util import six, total_seconds
-from spyne.const import xml_ns as ns
+from spyne.const import xml as ns
 
 from spyne import Null, AnyDict, Uuid, Array, ComplexModel, Date, Time, \
     Boolean, DateTime, Duration, Float, Integer, UnsignedInteger, Unicode, \
@@ -492,7 +492,7 @@ class TestPrimitive(unittest.TestCase):
         print(etree.tostring(element))
 
         element = element[0]
-        self.assertTrue(bool(element.attrib.get('{%s}nil' % ns.xsi)))
+        self.assertTrue(bool(element.attrib.get(ns.XSI('nil'))))
         value = XmlDocument().from_element(None, Null, element)
         self.assertEquals(None, value)
 
@@ -574,7 +574,7 @@ class TestPrimitive(unittest.TestCase):
         b = etree.Element('test')
         XmlDocument().to_parent(None, Boolean, None, b, ns_test)
         b = b[0]
-        self.assertEquals('true', b.get('{%s}nil' % ns.xsi))
+        self.assertEquals('true', b.get(ns.XSI('nil')))
 
         b = XmlDocument().from_element(None, Boolean, b)
         self.assertEquals(b, None)


### PR DESCRIPTION
As the selection of namespaces was divided between spyne.const.xml_ns and spyne.cons.xml, the resulting WSDL and XSD files when working on Soap12 where incorrect.
I migrated all uses op xml_ns to xml so the addition of Soap12 will be easier to make.

This also makes slight changes to the .travis.yml file, it now uses the matrix to select between testsuites.

This is the clean pull-request

Relates to #454 