### PR TITLE
feat(django): added support for django 1.11 and remove support 1.9

### DIFF
--- a/examples/django/rpctest/settings.py
+++ b/examples/django/rpctest/settings.py
@@ -42,6 +42,8 @@ MANAGERS = ADMINS
 
 db_name = os.path.join(tempfile.gettempdir(), 'rpctest.sqlite')
 
+ALLOWED_HOSTS = ['newtestserver']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.

--- a/setup.py
+++ b/setup.py
@@ -233,8 +233,8 @@ class RunTests(ExtendedTestCommand):
                                                     capture=self.capture) or ret
 
         ret = call_tox_subprocess('py%s-dj18' % PYVER) or ret
-        ret = call_tox_subprocess('py%s-dj19' % PYVER) or ret
         ret = call_tox_subprocess('py%s-dj110' % PYVER) or ret
+        ret = call_tox_subprocess('py%s-dj111' % PYVER) or ret
 
         if ret == 0:
             print(GREEN + "All that glisters is not gold." + RESET)

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@
 # python setup.py test
 
 [tox]
-envlist = py27-dj18, py27-dj19, py27-dj110,
-          py34-dj18, py34-dj19, py34-dj110,
-          py35-dj18, py35-dj19, py35-dj110,
-          py36-dj18, py36-dj19, py36-dj110,
+envlist = py27-dj18, py27-dj19, py27-dj110, py27-dj111,
+          py34-dj18, py34-dj19, py34-dj110, py34-dj111,
+          py35-dj18, py35-dj19, py35-dj110, py35-dj111,
+          py36-dj18, py36-dj19, py36-dj110, py36-dj111,
 
 usedevelop = True
 
@@ -50,6 +50,17 @@ deps =
     Django>=1.10,<1.11
     -rrequirements/test_django_req.txt
 
+[testenv:py27-dj111]
+basepython = {env:BASEPYTHON:python2.7}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.11,<1.12
+    -rrequirements/test_django_req.txt
+
 
 [testenv:py34-dj18]
 basepython = {env:BASEPYTHON:python3.4}
@@ -84,6 +95,16 @@ deps =
     Django>=1.10,<1.11
     -rrequirements/test_django_req.txt
 
+[testenv:py34-dj111]
+basepython = {env:BASEPYTHON:python3.4}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.11,<1.12
+    -rrequirements/test_django_req.txt
 
 
 [testenv:py35-dj18]
@@ -119,6 +140,18 @@ deps =
     Django>=1.9,<1.10
     -rrequirements/test_django_req.txt
 
+[testenv:py35-dj111]
+basepython = {env:BASEPYTHON:python3.5}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.11,<1.12
+    -rrequirements/test_django_req.txt
+
+
 [testenv:py36-dj18]
 basepython = {env:BASEPYTHON:python3.6}
 setenv =
@@ -138,7 +171,7 @@ setenv =
     TESTS = spyne/test/interop/test_django.py
 
 deps =
-    Django>=1.8,<1.9
+    Django>=1.9,<1.10
     -rrequirements/test_django_req.txt
 
 [testenv:py36-dj110]
@@ -149,5 +182,16 @@ setenv =
     TESTS = spyne/test/interop/test_django.py
 
 deps =
-    Django>=1.9,<1.10
+    Django>=1.10,<1.11
+    -rrequirements/test_django_req.txt
+
+[testenv:py36-dj111]
+basepython = {env:BASEPYTHON:python3.6}
+setenv =
+    DJANGO_SETTINGS_MODULE=rpctest.settings
+    PYTHONPATH = {toxinidir}/examples/django/
+    TESTS = spyne/test/interop/test_django.py
+
+deps =
+    Django>=1.11,<1.12
     -rrequirements/test_django_req.txt


### PR DESCRIPTION
Django 1.11 is new LTS version and django 1.9 ended is support on April 2017 so it should be discourage to use as it has lack of security patches.