### PR TITLE
Lxml warnings

### DIFF
--- a/spyne/protocol/soap/soap12.py
+++ b/spyne/protocol/soap/soap12.py
@@ -95,7 +95,7 @@ class Soap12(Soap11):
         tag_name = "{%s}Fault" % self.ns_soap_env
 
         if isinstance(inst.faultcode, string_types):
-            value, faultcodes  = self.gen_fault_codes(inst.faultcode)
+            value, faultcodes = self.gen_fault_codes(inst.faultcode)
 
             code = E("{%s}Code" % self.ns_soap_env)
             code.append(E("{%s}Value" % self.ns_soap_env, value))
@@ -135,7 +135,7 @@ class Soap12(Soap11):
         return self._fault_to_parent_impl(ctx, cls, inst, parent, ns, subelts)
 
     def fault_from_element(self, ctx, cls, element):
-        nsmap  = element.nsmap
+        nsmap = element.nsmap
 
         code = self.generate_faultcode(element)
         reason = element.find("soap:Reason/soap:Text", namespaces=nsmap).text.strip()
@@ -148,4 +148,4 @@ class Soap12(Soap11):
         if node:
             faultactor += node.text.strip()
         return cls(faultcode=code, faultstring=reason,
-                   faultactor = faultactor, detail=detail)
+                   faultactor=faultactor, detail=detail)

--- a/spyne/protocol/soap/soap12.py
+++ b/spyne/protocol/soap/soap12.py
@@ -73,7 +73,7 @@ class Soap12(Soap11):
         faultcode = []
         faultcode.append(element.find('soap:Code/soap:Value', namespaces=nsmap).text)
         subcode = element.find('soap:Code/soap:Subcode', namespaces=nsmap)
-        while subcode:
+        while subcode is not None:
             faultcode.append(subcode.find('soap:Value', namespaces=nsmap).text)
             subcode = subcode.find('soap:Subcode', namespaces=nsmap)
 
@@ -143,9 +143,9 @@ class Soap12(Soap11):
         node = element.find("soap:Node", namespaces=nsmap)
         detail = element.find("soap:Detail", namespaces=nsmap)
         faultactor = ''
-        if role:
+        if role is not None:
             faultactor += role.text.strip()
-        if node:
+        if node is not None:
             faultactor += node.text.strip()
         return cls(faultcode=code, faultstring=reason,
                    faultactor=faultactor, detail=detail)


### PR DESCRIPTION
Patch to suppress warning I am getting:
  /usr/local/lib/python2.7/site-packages/spyne/protocol/soap/soap12.py:76: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    while subcode:
  /usr/local/lib/python2.7/site-packages/spyne/protocol/soap/soap12.py:142: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    if role:
