### PR TITLE
Fix memory leak in ComplexModelBase.as_dict

### DIFF
--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -897,7 +897,7 @@ class ComplexModelBase(ModelBase):
         """
 
         return dict((
-            (k, getattr(self, k)) for k in self.get_flat_type_info(self)
+            (k, getattr(self, k)) for k in self.get_flat_type_info(self.__class__)
             if getattr(self, k) is not None
         ))
 


### PR DESCRIPTION
Fixes #578 

`get_flat_type_info` expects a class argument instead of an instance. Passing a model instance as an argument can cause a memory leak as outlined in the issue.