### PR TITLE
Tweak MIN_GC_INTERVAL import

### DIFF
--- a/spyne/context.py
+++ b/spyne/context.py
@@ -24,7 +24,7 @@ from time import time
 from copy import copy
 from collections import deque, defaultdict
 
-from spyne.const import MIN_GC_INTERVAL
+from spyne import const
 
 
 _LAST_GC_RUN = 0.0
@@ -393,7 +393,7 @@ class MethodContext(object):
 
         # this is important to have file descriptors returned in a timely manner
         t = time()
-        if (t - _LAST_GC_RUN) > MIN_GC_INTERVAL:
+        if (t - _LAST_GC_RUN) > const.MIN_GC_INTERVAL:
             gc.collect()
 
             dt = (time() - t)


### PR DESCRIPTION
Otherwise, setting:
`spyne.const.MIN_GC_INTERVAL = float('inf')`
after `spyne.context` was imported would be useless.

You would need to also set:
`spyne.context.MIN_GC_INTERVAL = float('inf')`
like we needed to set:
`pyne._base.MIN_GC_INTERVAL = float('inf')` before c1dd218ea.