### PR TITLE
Allow wsdl message part:name change

### DIFF
--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -49,7 +49,8 @@ from spyne.const import add_request_suffix
 
 
 def _produce_input_message(f, params, in_message_name, in_variable_names,
-                       no_ctx, no_self, argnames, body_style_str, self_ref_cls):
+                       no_ctx, no_self, argnames, body_style_str, self_ref_cls,
+                       in_message_part_name):
     arg_start = 0
     if no_ctx is False:
         arg_start += 1
@@ -130,6 +131,9 @@ def _produce_input_message(f, params, in_message_name, in_variable_names,
         message = ComplexModel.produce(type_name=in_message_name,
                                        namespace=ns, members=in_params)
         message.__namespace__ = ns
+    
+    if in_message_part_name:
+        message = message.customize(part_name=in_message_part_name)
 
     return message
 
@@ -191,6 +195,8 @@ def _produce_output_message(func_name, body_style_str, self_ref_cls,
                (body_style_str == 'wrapped' or _is_out_message_name_overridden):
         _out_message_name = '%s.%s' % \
                                (self_ref_cls.get_type_name(), _out_message_name)
+    
+    _out_message_part_name = kparams.pop('_message_part_name', None)
 
     out_params = TypeInfo()
 
@@ -230,6 +236,9 @@ def _produce_output_message(func_name, body_style_str, self_ref_cls,
 
         message.Attributes._wrapper = True
         message.__namespace__ = ns  # FIXME: is this necessary?
+    
+    if _out_message_part_name:
+        message = message.customize(part_name=_out_message_part_name)
 
     return message
 
@@ -354,6 +363,8 @@ def rpc(*params, **kparams):
         to override it for ``@rpc`` methods. It could be necessary to override
         it for ``@mrpc`` methods to add events and other goodies.
     :param _service: Same as ``_service``.
+    :param _message_part_name: Overrides the part name attribute of input/output
+        messages eg "parameters"
     """
 
     params = list(params)
@@ -457,6 +468,8 @@ def rpc(*params, **kparams):
 
             else:
                 _udd = {}
+            
+            _message_part_name = kparams.get('_message_part_name', None)
 
             body_style = BODY_STYLE_WRAPPED
             body_style_str = _validate_body_style(kparams)
@@ -468,7 +481,8 @@ def rpc(*params, **kparams):
 
             in_message = _produce_input_message(f, params,
                     _in_message_name, _in_arg_names, _no_ctx, _no_self,
-                                   _args, body_style_str, _self_ref_replacement)
+                                   _args, body_style_str, _self_ref_replacement,
+                                   _message_part_name)
 
             out_message = _produce_output_message(function_name,
                        body_style_str, _self_ref_replacement, _no_self, kparams)

--- a/spyne/decorator.py
+++ b/spyne/decorator.py
@@ -50,7 +50,7 @@ from spyne.const import add_request_suffix
 
 def _produce_input_message(f, params, in_message_name, in_variable_names,
                        no_ctx, no_self, argnames, body_style_str, self_ref_cls,
-                       in_message_part_name):
+                       in_wsdl_part_name):
     arg_start = 0
     if no_ctx is False:
         arg_start += 1
@@ -132,8 +132,8 @@ def _produce_input_message(f, params, in_message_name, in_variable_names,
                                        namespace=ns, members=in_params)
         message.__namespace__ = ns
     
-    if in_message_part_name:
-        message = message.customize(part_name=in_message_part_name)
+    if in_wsdl_part_name:
+        message = message.customize(wsdl_part_name=in_wsdl_part_name)
 
     return message
 
@@ -196,7 +196,7 @@ def _produce_output_message(func_name, body_style_str, self_ref_cls,
         _out_message_name = '%s.%s' % \
                                (self_ref_cls.get_type_name(), _out_message_name)
     
-    _out_message_part_name = kparams.pop('_message_part_name', None)
+    _out_wsdl_part_name = kparams.pop('_wsdl_part_name', None)
 
     out_params = TypeInfo()
 
@@ -237,8 +237,8 @@ def _produce_output_message(func_name, body_style_str, self_ref_cls,
         message.Attributes._wrapper = True
         message.__namespace__ = ns  # FIXME: is this necessary?
     
-    if _out_message_part_name:
-        message = message.customize(part_name=_out_message_part_name)
+    if _out_wsdl_part_name:
+        message = message.customize(wsdl_part_name=_out_wsdl_part_name)
 
     return message
 
@@ -363,7 +363,7 @@ def rpc(*params, **kparams):
         to override it for ``@rpc`` methods. It could be necessary to override
         it for ``@mrpc`` methods to add events and other goodies.
     :param _service: Same as ``_service``.
-    :param _message_part_name: Overrides the part name attribute of input/output
+    :param _wsdl_part_name: Overrides the part name attribute within wsdl input/output
         messages eg "parameters"
     """
 
@@ -469,7 +469,7 @@ def rpc(*params, **kparams):
             else:
                 _udd = {}
             
-            _message_part_name = kparams.get('_message_part_name', None)
+            _wsdl_part_name = kparams.get('_wsdl_part_name', None)
 
             body_style = BODY_STYLE_WRAPPED
             body_style_str = _validate_body_style(kparams)
@@ -482,7 +482,7 @@ def rpc(*params, **kparams):
             in_message = _produce_input_message(f, params,
                     _in_message_name, _in_arg_names, _no_ctx, _no_self,
                                    _args, body_style_str, _self_ref_replacement,
-                                   _message_part_name)
+                                   _wsdl_part_name)
 
             out_message = _produce_output_message(function_name,
                        body_style_str, _self_ref_replacement, _no_self, kparams)

--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -323,7 +323,7 @@ class Wsdl11(XmlSchema):
 
             for obj in objs:
                 part = SubElement(message, WSDL11("part"))
-                part.set('name', obj.get_part_name())
+                part.set('name', obj.get_wsdl_part_name())
                 part.set('element', obj.get_element_name_ns(self.interface))
 
     def add_messages_for_methods(self, service, root, messages):

--- a/spyne/interface/wsdl/wsdl11.py
+++ b/spyne/interface/wsdl/wsdl11.py
@@ -323,7 +323,7 @@ class Wsdl11(XmlSchema):
 
             for obj in objs:
                 part = SubElement(message, WSDL11("part"))
-                part.set('name', obj.get_element_name())
+                part.set('name', obj.get_part_name())
                 part.set('element', obj.get_element_name_ns(self.interface))
 
     def add_messages_for_methods(self, service, root, messages):

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -306,6 +306,11 @@ class ModelBase(object):
         type is seriazed under a ComplexModel.
         """
 
+        part_name = None
+        """This specifies which string should be used as message part name when this
+            type is serialized under a ComplexModel. Many clients expect "parameters"
+        """
+
         sqla_column_args = None
         """A dict that will be passed to SQLAlchemy's ``Column`` constructor as
         ``**kwargs``.
@@ -558,6 +563,10 @@ class ModelBase(object):
     @classmethod
     def get_element_name(cls):
         return cls.Attributes.sub_name or cls.get_type_name()
+    
+    @classmethod
+    def get_part_name(cls):
+        return cls.Attributes.part_name or cls.get_element_name()
 
     @classmethod
     def get_element_name_ns(cls, interface):

--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -306,9 +306,9 @@ class ModelBase(object):
         type is seriazed under a ComplexModel.
         """
 
-        part_name = None
-        """This specifies which string should be used as message part name when this
-            type is serialized under a ComplexModel. Many clients expect "parameters"
+        wsdl_part_name = None
+        """This specifies which string should be used as wsdl message part name when this
+            type is serialized under a ComplexModel ie."parameters".
         """
 
         sqla_column_args = None
@@ -565,8 +565,8 @@ class ModelBase(object):
         return cls.Attributes.sub_name or cls.get_type_name()
     
     @classmethod
-    def get_part_name(cls):
-        return cls.Attributes.part_name or cls.get_element_name()
+    def get_wsdl_part_name(cls):
+        return cls.Attributes.wsdl_part_name or cls.get_element_name()
 
     @classmethod
     def get_element_name_ns(cls, interface):


### PR DESCRIPTION
Addresses [#543](https://github.com/arskom/spyne/issues/543)

I've also had the need from a vendor spec to require the part name changed to "parameters".
Here's a solution without the need to hardcode wsdl11.py 