### PR TITLE
Changing print_stack to format_stack

### DIFF
--- a/spyne/model/complex.py
+++ b/spyne/model/complex.py
@@ -877,7 +877,7 @@ class ComplexModelBase(ModelBase):
             logger.warning("%r(0x%X) seems to be a customized class. It is not "
                     "supposed to be instantiated. You have been warned.",
                                                                    cls, id(cls))
-            logger.debug(traceback.print_stack())
+            logger.debug(traceback.format_stack())
 
         if cls_attr._xml_tag_body_as is not None:
             for arg, (xtba_key, xtba_type) in \


### PR DESCRIPTION
logger.debug(traceback.print_stack()) means that stack is first printed and then None is passed to logger.debug, resulting in tons of unnecessary output that cannot be suppressed.