### PR TITLE
Better Python3 compatibility

### DIFF
--- a/spyne/protocol/dictdoc/hier.py
+++ b/spyne/protocol/dictdoc/hier.py
@@ -318,6 +318,10 @@ class HierDictDocument(DictDocument):
 
         # parse input to set incoming data to related attributes.
         for k, v in items:
+            if not six.PY2:
+                if isinstance(k, bytes):
+                    k = k.decode('utf8')
+
             member = flat_type_info.get(k, None)
             if member is None:
                 member, k = flat_type_info.alt.get(k, (None, k))

--- a/spyne/test/protocol/test_msgpack.py
+++ b/spyne/test/protocol/test_msgpack.py
@@ -35,7 +35,7 @@ from spyne.model.complex import ComplexModel
 from spyne.model.primitive import Unicode
 from spyne.protocol.msgpack import MessagePackDocument
 from spyne.protocol.msgpack import MessagePackRpc
-from spyne.util.six import BytesIO
+from spyne.util.six import BytesIO, PY2
 from spyne.server import ServerBase
 from spyne.server.wsgi import WsgiApplication
 from spyne.test.protocol._test_dictdoc import TDictDocumentTest
@@ -111,12 +111,19 @@ class TestMessagePackRpc(unittest.TestCase):
         ret = b''.join(ret)
         print(repr(ret))
         print(msgpack.unpackb(ret))
-        s = msgpack.packb([1, 0, None, {'get_valuesResponse': {
-            'get_valuesResult': [
-                  {"KeyValuePair": {'value': 'b', 'key': 'a'}},
-                  {"KeyValuePair": {'value': 'd', 'key': 'c'}},
-                ]
-            }}
+        if PY2:
+            values_result = [
+                {"KeyValuePair": {'value': 'b', 'key': 'a'}},
+                {"KeyValuePair": {'value': 'd', 'key': 'c'}},
+            ]
+        else:
+            values_result = [
+                {"KeyValuePair": {'key': 'a', 'value': 'b'}},
+                {"KeyValuePair": {'key': 'c', 'value': 'd'}},
+            ]
+
+        s = msgpack.packb([1, 0, None, {'get_valuesResponse':
+            {'get_valuesResult': values_result}}
         ])
         print(s)
         assert ret == s


### PR DESCRIPTION
Based on the discussion in https://github.com/arskom/spyne/issues/632 I fixed a few test. Looked into a few more, but not sure how to fix them.

Additional question:
Are there any considerations dropping Python2.x support, because Python2 is nearly end of life now. https://www.python.org/dev/peps/pep-0373/