### PR TITLE
Use chain.from_iterable in msgpack.py

### DIFF
--- a/spyne/server/twisted/msgpack.py
+++ b/spyne/server/twisted/msgpack.py
@@ -325,7 +325,7 @@ class TwistedMessagePackProtocol(Protocol):
 
     def _write_single_chunk(self):
         try:
-            chunk = next(chain(*self.out_chunks))
+            chunk = next(chain.from_iterable(self.out_chunks))
         except StopIteration:
             chunk = None
             self.out_chunks.clear()


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.