### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,6 +291,10 @@ setup(
     maintainer='Burak Arslan',
     maintainer_email='burak+package@spyne.io',
     url='http://spyne.io',
+    project_urls={
+        'Documentation': 'http://spyne.io/docs',
+        'Source': 'https://github.com/arskom/spyne',
+    },
     license='LGPL-2.1',
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)