### PR TITLE
Fix string type issues with SOAP/Twisted

### DIFF
--- a/spyne/protocol/soap/soap11.py
+++ b/spyne/protocol/soap/soap11.py
@@ -191,7 +191,7 @@ class Soap11(XmlDocument):
             # work with proper POST requests.
             content_type = ctx.transport.get_request_content_type()
             http_verb = ctx.transport.get_request_method()
-            if content_type is None or http_verb != "POST":
+            if content_type is None or six.ensure_binary(http_verb) != b"POST":
                 ctx.transport.resp_code = HTTP_405
                 raise RequestNotAllowed(
                         "You must issue a POST request with the Content-Type "

--- a/spyne/server/twisted/http.py
+++ b/spyne/server/twisted/http.py
@@ -183,7 +183,7 @@ def _reconstruct_url(request):
         url_scheme = 'http'
 
     uri = _decode_path(request.uri)
-    return ''.join([url_scheme, "://", server_name, uri])
+    return ''.join([url_scheme, "://", server_name, uri.decode('utf-8')])
 
 
 class _Transformer(object):


### PR DESCRIPTION
Fix some issues found when trying to use Twisted with SOAP protocol in Python3