### PR TITLE
Introduced Safer SMTP Alternative: Added `SMTP_SSL`

### DIFF
--- a/spyne/util/email.py
+++ b/spyne/util/email.py
@@ -44,7 +44,7 @@ from email.encoders import encode_base64
 from spyne.util import six
 
 
-def email_exception(exception_address, message="", bcc=None):
+def email_exception(exception_address, message="", bcc=None, hostname=None, username=None, password=None, secure=False):
     # http://stackoverflow.com/questions/1095601/find-module-name-of-the-originating-exception-in-python
     frm = inspect.trace()[-1]
     mod = inspect.getmodule(frm[0])
@@ -63,7 +63,11 @@ def email_exception(exception_address, message="", bcc=None):
     msg['Subject'] = "(%s@%s) %s" % (getpass.getuser(), gethostname(), module_name)
 
     try:
-        smtp_object = smtplib.SMTP('localhost')
+        if secure:
+            smtp_object = smtplib.SMTP_SSL(hostname, smtplib.SMTP_SSL_PORT)
+            smtp_object.login(username, password)
+        else:
+            smtp_object = smtplib.SMTP('localhost')
         smtp_object.sendmail(sender, recipients, msg.as_string())
         logger.error("Error email sent")
 
@@ -73,7 +77,7 @@ def email_exception(exception_address, message="", bcc=None):
 
 
 def email_text_smtp(addresses, sender=None, subject='', message="",
-                                                     host='localhost', port=25):
+                                                     host='localhost', port=25, username=None, password=None, secure=False):
     if sender is None:
         sender = 'Spyne <robot@spyne.io>'
 
@@ -86,7 +90,11 @@ def email_text_smtp(addresses, sender=None, subject='', message="",
     msg['Date'] = formatdate()
     msg['Subject'] = subject
 
-    smtp_object = smtplib.SMTP(host, port)
+    if secure:
+        smtp_object = smtplib.SMTP_SSL(host, smtplib.SMTP_SSL_PORT)
+        smtp_object.login(username, password)
+    else:
+        smtp_object = smtplib.SMTP(host, port)
     if six.PY2:
         smtp_object.sendmail(sender, addresses, msg.as_string())
     else:


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [email.py](https://github.com/arskom/spyne/blob/master/spyne/util/email.py#L66), method: `email_exception`, a clear-text protocol such as FTP, Telnet or SMTP is used. These protocols transfer data without any encryption, which expose applications to a large range of risks. iCR suggested that data should be [transferred over only secure transport channels](https://cwe.mitre.org/data/definitions/319.html).


## Changes
- Added `SMTP_SSL` option to email.py with authentication system


## Previously Found & Fixed
- https://www.github.com/google/timesketch/pull/2940
- https://www.github.com/nasa-gibs/onearth/pull/177
- https://www.github.com/geopython/pycsw/pull/917


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
