### PR TITLE
DOC: Make license more clear

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,7 +291,7 @@ setup(
     maintainer='Burak Arslan',
     maintainer_email='burak+package@spyne.io',
     url='http://spyne.io',
-    license='LGPL-2.1',
+    license='LGPL-2.1-or-later',
     zip_safe=False,
     install_requires=[
       'pytz',


### PR DESCRIPTION
According to the file headers, the license of *spyne* is LPGL-2.1-or-later. This PR makes this clear from the package license itself as well.