### PR TITLE
Update customized six version

### DIFF
--- a/spyne/util/six.py
+++ b/spyne/util/six.py
@@ -363,6 +363,8 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("splittag", "urllib", "urllib.parse"),
     MovedAttribute("splituser", "urllib", "urllib.parse"),
     MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("splittype", "urllib", "urllib.parse"),
+    MovedAttribute("splithost", "urllib", "urllib.parse"),
     MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
     MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
     MovedAttribute("uses_params", "urlparse", "urllib.parse"),
@@ -531,6 +533,7 @@ if PY3:
     _func_code = "__code__"
     _func_defaults = "__defaults__"
     _func_globals = "__globals__"
+    _func_name = "__name__"
 else:
     _meth_func = "im_func"
     _meth_self = "im_self"
@@ -539,6 +542,7 @@ else:
     _func_code = "func_code"
     _func_defaults = "func_defaults"
     _func_globals = "func_globals"
+    _func_name = "func_name"
 
 
 try:
@@ -592,6 +596,7 @@ get_function_closure = operator.attrgetter(_func_closure)
 get_function_code = operator.attrgetter(_func_code)
 get_function_defaults = operator.attrgetter(_func_defaults)
 get_function_globals = operator.attrgetter(_func_globals)
+get_function_name = operator.attrgetter(_func_name)
 
 
 if PY3:


### PR DESCRIPTION
spyne induce a AttributeError during tests in a project using spyne. Update the customized six version.
This may also be related to issue #700.

Regards
    Benedikt Spranger