### PR TITLE
Fix: Update import for Python 3.12 compatibility

### DIFF
--- a/spyne/util/oset.py
+++ b/spyne/util/oset.py
@@ -1,6 +1,6 @@
 # http://code.activestate.com/recipes/576694/
 
-from spyne.util.six.moves.collections_abc import MutableSet
+from collections.abc import MutableSet
 
 KEY, PREV, NEXT = list(range(3))
 


### PR DESCRIPTION
This PR addresses a compatibility issue with Python 3.12. The `six` library is no longer included in Python 3.12, causing an import error in `spyne/util/oset.py`.

Changes made:
- Updated the import in `spyne/util/oset.py` from `spyne.util.six.moves.collections_abc` to `collections.abc`.

This change maintains backwards compatibility while fixing the issue for Python 3.12 users.