### PR TITLE
Fixed some type mismatches in case when mtom/xop is in incoming message

### DIFF
--- a/spyne/model/_base.py
+++ b/spyne/model/_base.py
@@ -240,7 +240,8 @@ class AttributesMeta(type(object)):
 
 class ModelBaseMeta(type(object)):
     def __getitem__(self, item):
-        return self.customize(**item)
+        if isinstance(item, dict):
+            return self.customize(**item)
 
     def customize(self, **kwargs):
         """Duplicates cls and overwrites the values in ``cls.Attributes`` with


### PR DESCRIPTION
I'm building simple SOAP-service with `Spyne 2.14` and a SOAP-client with `Zeep 4.3.1` + `pymtom_xop 0.0.2`  on `Python 3.10` as part of my university's homework.

I've faced the problem using `Spyne` for handling incoming `MTOM/XOP` attachments. There were multiple not handled exceptions, generally because of types mismatching and not-declared variables. I'm wondering how linter skipped such mistakes, anyways...

I tried my best to catch and handle them, so now it works almost fine. I still receive HTTP 500 for mp3 files (yeah, very strange), but for now I'll leave it as is 🫤